### PR TITLE
added option "--backup" to use parameter "--mirror" when cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - ghorgignore to ignore specific repos
 - skip archived repos flag
 - how to fix ulmits in readme
+- dedicated backup flag
 ### Changed
 ### Deprecated
 ### Removed


### PR DESCRIPTION
## Status
Basically a proposal. My first lines in Go so be gentle please.

## Description
Introduce flag `--backup`. Backup repos will be cloned with flag `--mirror` and updated with `git remote update`.