### PR TITLE
Creating new var to hold the parentFolder name

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -19,6 +19,7 @@ import (
 var (
 	protocol          string
 	path              string
+	parentFolder      string
 	branch            string
 	token             string
 	cloneType         string
@@ -162,6 +163,7 @@ var cloneCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		parseParentFolder(argz)
 		args = argz
 
 		CloneAllRepos()
@@ -211,7 +213,7 @@ func getAllUserCloneUrls() ([]Repo, error) {
 }
 
 func createDirIfNotExist() {
-	if _, err := os.Stat(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + args[0] + "_ghorg"); os.IsNotExist(err) {
+	if _, err := os.Stat(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + parentFolder + "_ghorg"); os.IsNotExist(err) {
 		err = os.MkdirAll(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), 0700)
 		if err != nil {
 			panic(err)
@@ -354,10 +356,10 @@ func CloneAllRepos() {
 				path = repo.Path
 			}
 
-			repoDir := os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + args[0] + "_ghorg" + "/" + path
+			repoDir := os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + parentFolder + "_ghorg" + "/" + path
 
 			if os.Getenv("GHORG_BACKUP") == "true" {
-				repoDir = os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + args[0] + "_ghorg_backup" + "/" + path
+				repoDir = os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO") + parentFolder + "_ghorg_backup" + "/" + path
 			}
 
 			if repoExistsLocally(repoDir) == true {
@@ -451,9 +453,9 @@ func CloneAllRepos() {
 
 	// TODO: fix all these if else checks with ghorg_backups
 	if os.Getenv("GHORG_BACKUP") == "true" {
-		colorlog.PrintSuccess(fmt.Sprintf("Finished! %s%s_ghorg_backup", os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), args[0]))
+		colorlog.PrintSuccess(fmt.Sprintf("Finished! %s%s_ghorg_backup", os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder))
 	} else {
-		colorlog.PrintSuccess(fmt.Sprintf("Finished! %s%s_ghorg", os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), args[0]))
+		colorlog.PrintSuccess(fmt.Sprintf("Finished! %s%s_ghorg", os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder))
 	}
 }
 
@@ -504,4 +506,8 @@ func addTokenToHTTPSCloneURL(url string, token string) string {
 	}
 
 	return "https://" + token + "@" + splitURL[1]
+}
+
+func parseParentFolder(argz []string) {
+	parentFolder = strings.ToLower(argz[0])
 }

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import "testing"
+
+func TestShouldLowerRegularString(t *testing.T) {
+
+	upperName := "RepoName"
+	parseParentFolder([]string{upperName})
+
+	if parentFolder != "reponame" {
+		t.Errorf("Wrong folder name, expected: %s, got: %s", upperName, parentFolder)
+	}
+}
+
+func TestShouldNotChangeLowerCasedRegularString(t *testing.T) {
+
+	lowerName := "repo-name"
+	parseParentFolder([]string{lowerName})
+
+	if parentFolder != "repo-name" {
+		t.Errorf("Wrong folder name, expected: %s, got: %s", lowerName, parentFolder)
+	}
+}
+
+func TestShouldNotChangeNonLettersString(t *testing.T) {
+
+	numberName := "1234567_8"
+	parseParentFolder([]string{numberName})
+
+	if parentFolder != "1234567_8" {
+		t.Errorf("Wrong folder name, expected: %s, got: %s", numberName, parentFolder)
+	}
+}


### PR DESCRIPTION
This commit creates a new global var and stores the parent folder name on it.
This PR fixes #69 

## Status
**READY**

## Description
This PR is lower-casing the main ghorg folder name. 
It stores the lower-cased folder name on a var (during cobra initialization) and then it changes all folder references (using args[0] to get the folder name) to the new variable.
I decided to keep the args[0] reference for project, user and organization names because they may be case sensitive. Therefore, I'm changing the folder name only.

