### PR TITLE
Adding partial clone filtering

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -443,7 +443,7 @@ func CloneAllRepos() {
 					args = append(args, "--mirror")
 				}
 				if os.Getenv("GHORG_FILTER") != "" {
-					args = append(args, "--filter=" + os.Getenv("GHORG_FILTER"))
+					args = append(args, "--filter="+os.Getenv("GHORG_FILTER"))
 				}
 
 				cmd := exec.Command("git", args...)

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -156,8 +156,8 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 	}
 
 	if cmd.Flags().Changed("filter") {
-		d := cmd.Flag("filter").Value.String()
-		os.Setenv("GHORG_FILTER", d)
+		filter := cmd.Flag("filter").Value.String()
+		os.Setenv("GHORG_FILTER", filter)
 	}
 
 	configs.GetOrSetToken()

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -437,6 +437,7 @@ func CloneAllRepos() {
 				}
 			} else {
 				// if https clone and github/gitlab add personal access token to url
+				
 				args := []string{"clone", repo.CloneURL, repoDir}
 				if os.Getenv("GHORG_BACKUP") == "true" {
 					args = append(args, "--mirror")

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -437,7 +437,7 @@ func CloneAllRepos() {
 				}
 			} else {
 				// if https clone and github/gitlab add personal access token to url
-				
+
 				args := []string{"clone", repo.CloneURL, repoDir}
 				if os.Getenv("GHORG_BACKUP") == "true" {
 					args = append(args, "--mirror")

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -438,7 +438,6 @@ func CloneAllRepos() {
 			} else {
 				// if https clone and github/gitlab add personal access token to url
 				args := []string{"clone", repo.CloneURL, repoDir}
-				fmt.Printf("filter: %v",os.Getenv("GHORG_FILTER"))
 				if os.Getenv("GHORG_BACKUP") == "true" {
 					args = append(args, "--mirror")
 				}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -34,6 +34,7 @@ var (
 	baseURL           string
 	concurrency       string
 	outputDir         string
+	filter            string
 	topics            string
 	skipArchived      bool
 	backup            bool
@@ -62,6 +63,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&concurrency, "concurrency", "", "", "GHORG_CONCURRENCY - max goroutines to spin up while cloning (default 25)")
 	cloneCmd.Flags().StringVarP(&topics, "topics", "", "", "GHORG_GITHUB_TOPICS - comma seperated list of github topics to filter for")
 	cloneCmd.Flags().StringVarP(&outputDir, "output-dir", "", "", "GHORG_OUTPUT_DIR - name of directory repos will be cloned into, will force underscores and always append _ghorg (default {org/repo being cloned}_ghorg)")
+	cloneCmd.Flags().StringVarP(&filter, "filter", "", "", "GHORG_FILTER - Partial clone filtering, such as blob:none")
 
 }
 
@@ -151,6 +153,11 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 	if cmd.Flags().Changed("output-dir") {
 		d := cmd.Flag("output-dir").Value.String()
 		os.Setenv("GHORG_OUTPUT_DIR", d)
+	}
+
+	if cmd.Flags().Changed("filter") {
+		d := cmd.Flag("filter").Value.String()
+		os.Setenv("GHORG_FILTER", d)
 	}
 
 	configs.GetOrSetToken()
@@ -430,10 +437,13 @@ func CloneAllRepos() {
 				}
 			} else {
 				// if https clone and github/gitlab add personal access token to url
-
 				args := []string{"clone", repo.CloneURL, repoDir}
+				fmt.Printf("filter: %v",os.Getenv("GHORG_FILTER"))
 				if os.Getenv("GHORG_BACKUP") == "true" {
 					args = append(args, "--mirror")
+				}
+				if os.Getenv("GHORG_FILTER") != "" {
+					args = append(args, "--filter=" + os.Getenv("GHORG_FILTER"))
 				}
 
 				cmd := exec.Command("git", args...)

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -89,6 +89,7 @@ func initConfig() {
 	getOrSetDefaults("GHORG_SCM_BASE_URL")
 	getOrSetDefaults("GHORG_PRESERVE_DIRECTORY_STRUCTURE")
 	getOrSetDefaults("GHORG_OUTPUT_DIR")
+	getOrSetDefaults("GHORG_FILTER")
 }
 
 // Load triggers the configs to load first, not sure if this is actually needed

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -105,3 +105,12 @@ GHORG_CONCURRENCY:
 # default: {org/user you are cloning}_ghorg
 # flag (--output-dir)
 GHORG_OUTPUT_DIR:
+
+# Partial clone filter that will be used to grab a subset of reachable objects
+# https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---filterltfilter-specgt
+# The most common use case would be "blob:none" to prevent binary objects from being downloaded
+# Multiple filters can be specified by "combine:<filter1>+<filter2>+…​<filterN>"
+# This can only be set during the initial clone!
+# default: ""
+# flag (--filter)
+GHORG_FILTER:


### PR DESCRIPTION
## Status
DEVELOPMENT

## Description
Implements this: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---filterltfilter-specgt

Reason... quicker clones (and pulls) if we can filter out binary files!

When repos are cloned with this option it puts a "partialclonefiltering" config in that repos .git/config, so even subsequent pulls keep the filtering.

Only works with Git 2.19+ but the README does mention that.

Do you think we need to do something about the non-clone case? If a user provides a filter but it is not the initially clone, the filter is meaningless. Maybe it could output a warning?
