### PR TITLE
remove gitlab namespaces concept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [1.3.2] - unrealeased
+## [1.4.1] - unrealeased
 ### Added
 - GHORG_GITHUB_TOPICS to filter cloning repos matching specified topics; thanks @ryanaross
 - GHORG_MATCH_PREFIX to filter cloning repos by prefix
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+- GHORG_GITLAB_DEFAULT_NAMESPACE
 ### Fixed
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $ vi $HOME/.config/ghorg/conf.yaml # (optional but recommended)
 $ ghorg clone someorg
 $ ghorg clone someorg --concurrency=50 --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
 $ ghorg clone someuser --clone-type=user --protocol=ssh --branch=develop --color=off
-$ ghorg clone gitlab-org --scm=gitlab --namespace=gitlab-org/security-products
-$ ghorg clone gitlab-org --scm=gitlab --base-url=https://gitlab.internal.yourcompany.com --preserve-dir
+$ ghorg clone gitlab-group --scm=gitlab --base-url=https://gitlab.internal.yourcompany.com --preserve-dir
+$ ghorg clone gitlab-group/gitlab-subgroup --scm=gitlab --base-url=https://gitlab.internal.yourcompany.com
 $ ghorg clone --help
 ```
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -55,7 +55,6 @@ func init() {
 	cloneCmd.Flags().StringVarP(&scmType, "scm", "s", "", "GHORG_SCM_TYPE - type of scm used, github, gitlab or bitbucket (default github)")
 	// TODO: make gitlab terminology make sense https://about.gitlab.com/2016/01/27/comparing-terms-gitlab-github-bitbucket/
 	cloneCmd.Flags().StringVarP(&cloneType, "clone-type", "c", "", "GHORG_CLONE_TYPE - clone target type, user or org (default org)")
-	cloneCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "GHORG_GITLAB_DEFAULT_NAMESPACE - gitlab only: limits clone targets to a specific namespace e.g. --namespace=gitlab-org/security-products")
 	cloneCmd.Flags().BoolVar(&skipArchived, "skip-archived", false, "GHORG_SKIP_ARCHIVED - skips archived repos, github/gitlab only")
 	cloneCmd.Flags().BoolVar(&skipArchived, "preserve-dir", false, "GHORG_PRESERVE_DIRECTORY_STRUCTURE - clones repos in a directory structure that matches gitlab namespaces eg company/unit/subunit/app would clone into *_ghorg/unit/subunit/app, gitlab only")
 	cloneCmd.Flags().BoolVar(&backup, "backup", false, "GHORG_BACKUP - backup mode, clone as mirror, no working copy (ignores branch parameter)")
@@ -106,10 +105,6 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 
 	if cmd.Flags().Changed("bitbucket-username") {
 		os.Setenv("GHORG_BITBUCKET_USERNAME", cmd.Flag("bitbucket-username").Value.String())
-	}
-
-	if cmd.Flags().Changed("namespace") {
-		os.Setenv("GHORG_GITLAB_DEFAULT_NAMESPACE", cmd.Flag("namespace").Value.String())
 	}
 
 	if cmd.Flags().Changed("clone-type") {

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -76,7 +76,6 @@ func initConfig() {
 	getOrSetDefaults("GHORG_CLONE_PROTOCOL")
 	getOrSetDefaults("GHORG_CLONE_TYPE")
 	getOrSetDefaults("GHORG_SCM_TYPE")
-	getOrSetDefaults("GHORG_GITLAB_DEFAULT_NAMESPACE")
 	getOrSetDefaults("GHORG_COLOR")
 	getOrSetDefaults("GHORG_SKIP_ARCHIVED")
 	getOrSetDefaults("GHORG_BACKUP")
@@ -126,8 +125,6 @@ func getOrSetDefaults(envVar string) {
 			os.Setenv(envVar, "org")
 		case "GHORG_SCM_TYPE":
 			os.Setenv(envVar, "github")
-		case "GHORG_GITLAB_DEFAULT_NAMESPACE":
-			os.Setenv(envVar, "unset")
 		case "GHORG_COLOR":
 			os.Setenv(envVar, "on")
 		case "GHORG_SKIP_ARCHIVED":

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -13,7 +13,6 @@ func TestDefaultSettings(t *testing.T) {
 	protocol := os.Getenv("GHORG_CLONE_PROTOCOL")
 	scm := os.Getenv("GHORG_SCM_TYPE")
 	cloneType := os.Getenv("GHORG_CLONE_TYPE")
-	namespace := os.Getenv("GHORG_GITLAB_DEFAULT_NAMESPACE")
 
 	if branch != "master" {
 		t.Errorf("Default branch should be master, got: %v", branch)
@@ -29,10 +28,6 @@ func TestDefaultSettings(t *testing.T) {
 
 	if cloneType != "org" {
 		t.Errorf("Default clone type should be org, got: %v", cloneType)
-	}
-
-	if namespace != "unset" {
-		t.Errorf("Default gitlab namespace type should be unset, got: %v", namespace)
 	}
 
 }

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -30,9 +30,6 @@ GHORG_SCM_BASE_URL:
 # flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
 GHORG_GITLAB_TOKEN:
 
-# flag (--namespace, -n)
-GHORG_GITLAB_DEFAULT_NAMESPACE:
-
 # clones repos in a directory structure that matches gitlab namespaces eg company/unit/subunit/app would clone into *_ghorg/unit/subunit/app
 # default: false
 # flag (--preserve-dir)


### PR DESCRIPTION
## Status
Ready

## Description
Namespaces is the wrong idea. Users should be able to clone all gitlab repos, or groups/subgroups within a gitlab instance. 
