### PR TITLE
Add clone me option for github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-## [] - unreleased
+## [1.5.2] - unreleased
 ### Added
+- ghorg clone me to clone all of your own private repos from github
 ### Changed
 ### Deprecated
 ### Removed

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,6 +15,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Ghorg",
 	Long:  `All software has versions. This is Ghorg's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("1.5.1")
+		fmt.Println("1.5.2")
 	},
 }

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -77,6 +77,7 @@ GHORG_BRANCH:
 
 # Type of entity to clone (user or org)
 # default: org
+# to clone all of your own repos from github use "ghorg clone me --clone-type=user"
 # flag (--clone-type, -c)
 GHORG_CLONE_TYPE:
 

--- a/scm/github.go
+++ b/scm/github.go
@@ -69,7 +69,7 @@ func (c Github) GetUserRepos(targetUser string) ([]Repo, error) {
 	}
 
 	opt := &github.RepositoryListOptions{
-		Type:        "all",
+		Visibility:  "all",
 		ListOptions: github.ListOptions{PerPage: c.perPage},
 	}
 
@@ -77,8 +77,14 @@ func (c Github) GetUserRepos(targetUser string) ([]Repo, error) {
 
 	// get all pages of results
 	var allRepos []*github.Repository
+
 	for {
 
+		if targetUser == "me" {
+			targetUser = ""
+		}
+
+		// List the repositories for a user. Passing the empty string will list repositories for the authenticated user.
 		repos, resp, err := c.Repositories.List(context.Background(), targetUser, opt)
 
 		if err != nil {


### PR DESCRIPTION
addresses https://github.com/gabrie30/ghorg/issues/122

go-githubs Repositories.List does not return private repos even when specified in the RepositoryListOptions. This may be a bug with the library. However, passing an empty string instead of a username will fetch all of the repos for the personal access token. I was not able to figure out how I could get a github username associated with a personal access token, this is likely for security, so I cannot tell if the user is trying to clone their own repos. For this reason "me" is now reserved when cloning repos from github so that a user can clone their own repos, sorry @me, no one will be able to clone your repos :(

