### PR TITLE
Fix sample config for gitlab URL

### DIFF
--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -49,7 +49,7 @@ GHORG_BITBUCKET_USERNAME:
 # |G|E|N|E|R|A|L| |C|O|N|F|I|G|U|R|A|T|I|O|N|
 # +-+-+-+-+-+-+-+ +-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-# Change SCM base url, for on self hosted instances (for gitlab, use format of https://git.mydomain.com/api/v3), gitea require this
+# Change SCM base url, for on self hosted instances, gitea require this
 # default: uses github/gitlab public api
 # flag (--base-url)
 GHORG_SCM_BASE_URL:


### PR DESCRIPTION
I got this error when following the current doc on self-hosted GitLab 13.x:

```
<$> ghorg clone org

 +-+-+-+-+ +-+-+ +-+-+-+-+-+
 |T|I|M|E| |T|O| |G|H|O|R|G|
 +-+-+-+-+ +-+-+ +-+-+-+-+-+

*************************************
* SCM           : gitlab
* Type          : org
* Protocol      : ssh
* Location      : ...
* Concurrency   : 25
* Base URL      : https://somegitlab.instance.com/api/v3/
* Config Used   : .../conf.yaml
*************************************

Encountered an error, aborting
GET https://somegitlab.instance.com/api/v3/api/v4/groups/org/projects: 410 {error: API V3 is no longer supported. Use API V4 instead.}
```

While removing the `api/v3/` fixed the issue.