### PR TITLE
Update gitlab client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+
+## [1.7.3] - Unreleased
+### Added
+### Changed
+- Gitlab client to skip verification of ssl certificates for hosted gitlab servers
+### Deprecated
+### Removed
+### Fixed
+### Security
 ## [1.7.2] - 10/14/21
 ### Added
 - GHORG_NO_CLEAN only clones new repos and does not perform a git clean on existing repos; thanks @harmathy

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,6 +11,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Ghorg",
 	Long:  `All software has versions. This is Ghorg's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v1.7.2")
+		fmt.Println("v1.7.3")
 	},
 }

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -1,7 +1,9 @@
 package scm
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 
@@ -183,7 +185,12 @@ func (_ Gitlab) NewClient() (Client, error) {
 	var err error
 	var c *gitlab.Client
 	if baseURL != "" {
-		c, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL))
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+		opt := gitlab.WithHTTPClient(client)
+		c, err = gitlab.NewClient(token, gitlab.WithBaseURL(baseURL), opt)
 	} else {
 		c, err = gitlab.NewClient(token)
 	}


### PR DESCRIPTION
Update gitlab client to skip certificate verification on hosted instances

Fixes https://github.com/gabrie30/ghorg/issues/126