### PR TITLE
fix: allow to override config with env variables

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,6 +198,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&config, "config", "", "GHORG_CONFIG - manually set the path to your config file")
 
 	viper.SetDefault("config", configs.DefaultConfFile())
+	viper.AutomaticEnv()
 
 	_ = viper.BindPFlag("color", rootCmd.PersistentFlags().Lookup("color"))
 	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))


### PR DESCRIPTION
## Status
**READY**

## Description
Currently it is not possible to override ghorg settings solely by environment variables. for example `GHORG_ABSOLUTE_PATH_TO_CLONE_TO` will be completely ignored when set as env variable. (note: env variables are basically ignored for all values that have defaults).

This PR should fix that and env variables take precedence over the config file values.
