### PR TITLE
Add "prune" feature to `clone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [1.7.16] - 6/2/22
+### Added
+- GHORG_PRUNE setting which allows a user to have Ghorg automatically remove items from their local
+  org clone which have been removed (or archived, if GHORG_SKIP_ARCHIVED is set) upstream.
+- GHORG_PRUNE_NO_CONFIRM which disables the interactive yes/no prompt for every item to be deleted
+  when pruning.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+
 ## [1.7.15] - 5/29/22
 ### Added
 - CodeQL security analysis action

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -677,12 +677,14 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 		// The first time around, we set userAgreesToDelete to true, otherwise we'd immediately
 		// break out of the loop.
 		userAgreesToDelete := true
+		pruneNoConfirm := os.Getenv("GHORG_PRUNE_NO_CONFIRM") == "true"
 		for _, f := range files {
 			// For each item in the org's clone directory, let's make sure we found a corresponding
 			// repo on the remote.  We check userAgreesToDelete here too, so that if the user says
 			// "No" at any time, we stop trying to prune things altogether.
 			if userAgreesToDelete && !sliceContainsNamedRepo(cloneTargets, f.Name()) {
-				userAgreesToDelete = interactiveYesNoPrompt(
+				// If the user specified --prune-no-confirm, we needn't prompt interactively.
+				userAgreesToDelete = pruneNoConfirm || interactiveYesNoPrompt(
 					fmt.Sprintf("%s was not found in remote.  Do you want to prune it?", f.Name()))
 				if userAgreesToDelete {
 					colorlog.PrintSubtleInfo(

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -114,6 +114,10 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_PRUNE", "true")
 	}
 
+	if cmd.Flags().Changed("prune-no-confirm") {
+		os.Setenv("GHORG_PRUNE_NO_CONFIRM", "true")
+	}
+
 	if cmd.Flags().Changed("fetch-all") {
 		os.Setenv("GHORG_FETCH_ALL", "true")
 	}
@@ -789,7 +793,11 @@ func PrintConfigs() {
 		colorlog.PrintInfo("* No Clean      : " + "true")
 	}
 	if os.Getenv("GHORG_PRUNE") == "true" {
-		colorlog.PrintInfo("* Prune         : " + "true")
+		noConfirmText := ""
+		if os.Getenv("GHORG_PRUNE_NO_CONFIRM") == "true" {
+			noConfirmText = " (skipping confirmation)"
+		}
+		colorlog.PrintInfo("* Prune         : " + "true" + noConfirmText)
 	}
 	if os.Getenv("GHORG_FETCH_ALL") == "true" {
 		colorlog.PrintInfo("* Fetch All     : " + "true")

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -109,6 +109,10 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_NO_CLEAN", "true")
 	}
 
+	if cmd.Flags().Changed("prune") {
+		os.Setenv("GHORG_PRUNE", "true")
+	}
+
 	if cmd.Flags().Changed("fetch-all") {
 		os.Setenv("GHORG_FETCH_ALL", "true")
 	}
@@ -698,6 +702,9 @@ func PrintConfigs() {
 	}
 	if os.Getenv("GHORG_NO_CLEAN") == "true" {
 		colorlog.PrintInfo("* No Clean      : " + "true")
+	}
+	if os.Getenv("GHORG_PRUNE") == "true" {
+		colorlog.PrintInfo("* Prune         : " + "true")
 	}
 	if os.Getenv("GHORG_FETCH_ALL") == "true" {
 		colorlog.PrintInfo("* Fetch All     : " + "true")

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -689,6 +689,23 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 	}
 }
 
+func interactiveYesNoPrompt(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print(strings.TrimSpace(prompt) + " (y/N) ")
+	s, err := reader.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+
+	if s == "y" || s == "yes" {
+		return true
+	}
+	return false
+}
+
 // There's probably a nicer way of finding whether any scm.Repo in the slice matches a given name.
 func sliceContainsNamedRepo(haystack []scm.Repo, needle string) bool {
 	for _, repo := range haystack {

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -476,7 +476,7 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 				repoSlug = repo.Path
 			}
 
-			repo.HostPath = filepath.Join(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder, configs.GetCorrectFilePathSeparator(), repoSlug)
+			repo.HostPath = filepath.Join(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder, repoSlug)
 
 			if repo.IsWiki {
 				if !strings.HasSuffix(repo.HostPath, ".wiki") {
@@ -485,7 +485,7 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 			}
 
 			if os.Getenv("GHORG_BACKUP") == "true" {
-				repo.HostPath = filepath.Join(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder+"_backup", configs.GetCorrectFilePathSeparator(), repoSlug)
+				repo.HostPath = filepath.Join(os.Getenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO"), parentFolder+"_backup", repoSlug)
 			}
 
 			action := "cloning"

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -689,7 +689,10 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 				if userAgreesToDelete {
 					colorlog.PrintSubtleInfo(
 						fmt.Sprintf("Deleting %s", filepath.Join(cloneLocation, f.Name())))
-					os.RemoveAll(filepath.Join(cloneLocation, f.Name()))
+					err = os.RemoveAll(filepath.Join(cloneLocation, f.Name()))
+					if err != nil {
+						log.Fatal(err)
+					}
 				} else {
 					colorlog.PrintError("Pruning cancelled by user.  No more prunes will be considered.")
 				}

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/gabrie30/ghorg/colorlog"
-	"github.com/gabrie30/ghorg/configs"
 	"github.com/spf13/cobra"
 )
 
@@ -58,7 +57,7 @@ func listGhorgDir(arg string) {
 
 	for _, f := range files {
 		if f.IsDir() {
-			str := filepath.Join(path, configs.GetCorrectFilePathSeparator(), f.Name())
+			str := filepath.Join(path, f.Name())
 			colorlog.PrintSubtleInfo(str)
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	backup                       bool
 	noClean                      bool
 	dryRun                       bool
+	prune                        bool
 	cloneWiki                    bool
 	preserveDir                  bool
 	insecureGitlabClient         bool
@@ -102,6 +103,8 @@ func getOrSetDefaults(envVar string) {
 		case "GHORG_FETCH_ALL":
 			os.Setenv(envVar, "false")
 		case "GHORG_DRY_RUN":
+			os.Setenv(envVar, "false")
+		case "GHORG_PRUNE":
 			os.Setenv(envVar, "false")
 		case "GHORG_INSECURE_GITLAB_CLIENT":
 			os.Setenv(envVar, "false")
@@ -176,6 +179,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_SKIP_FORKS")
 	getOrSetDefaults("GHORG_NO_CLEAN")
 	getOrSetDefaults("GHORG_FETCH_ALL")
+	getOrSetDefaults("GHORG_PRUNE")
 	getOrSetDefaults("GHORG_DRY_RUN")
 	getOrSetDefaults("GHORG_CLONE_WIKI")
 	getOrSetDefaults("GHORG_INSECURE_GITLAB_CLIENT")
@@ -228,6 +232,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&cloneType, "clone-type", "c", "", "GHORG_CLONE_TYPE - clone target type, user or org (default org)")
 	cloneCmd.Flags().BoolVar(&skipArchived, "skip-archived", false, "GHORG_SKIP_ARCHIVED - skips archived repos, github/gitlab/gitea only")
 	cloneCmd.Flags().BoolVar(&noClean, "no-clean", false, "GHORG_NO_CLEAN - only clones new repos and does not perform a git clean on existing repos")
+	cloneCmd.Flags().BoolVar(&prune, "prune", false, "GHORG_PRUNE - remove local clones if not found on remote")
 	cloneCmd.Flags().BoolVar(&fetchAll, "fetch-all", false, "GHORG_FETCH_ALL - fetches all remote branches for each repo by running a git fetch --all")
 	cloneCmd.Flags().BoolVar(&dryRun, "dry-run", false, "GHORG_DRY_RUN - perform a dry run of the clone; fetches repos but does not clone them")
 	cloneCmd.Flags().BoolVar(&insecureGitlabClient, "insecure-gitlab-client", false, "GHORG_INSECURE_GITLAB_CLIENT - skip TLS certificate verification for hosted gitlab instances")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 	noClean                      bool
 	dryRun                       bool
 	prune                        bool
+	pruneNoConfirm               bool
 	cloneWiki                    bool
 	preserveDir                  bool
 	insecureGitlabClient         bool
@@ -105,6 +106,8 @@ func getOrSetDefaults(envVar string) {
 		case "GHORG_DRY_RUN":
 			os.Setenv(envVar, "false")
 		case "GHORG_PRUNE":
+			os.Setenv(envVar, "false")
+		case "GHORG_PRUNE_NO_CONFIRM":
 			os.Setenv(envVar, "false")
 		case "GHORG_INSECURE_GITLAB_CLIENT":
 			os.Setenv(envVar, "false")
@@ -180,6 +183,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_NO_CLEAN")
 	getOrSetDefaults("GHORG_FETCH_ALL")
 	getOrSetDefaults("GHORG_PRUNE")
+	getOrSetDefaults("GHORG_PRUNE_NO_CONFIRM")
 	getOrSetDefaults("GHORG_DRY_RUN")
 	getOrSetDefaults("GHORG_CLONE_WIKI")
 	getOrSetDefaults("GHORG_INSECURE_GITLAB_CLIENT")
@@ -233,6 +237,7 @@ func init() {
 	cloneCmd.Flags().BoolVar(&skipArchived, "skip-archived", false, "GHORG_SKIP_ARCHIVED - skips archived repos, github/gitlab/gitea only")
 	cloneCmd.Flags().BoolVar(&noClean, "no-clean", false, "GHORG_NO_CLEAN - only clones new repos and does not perform a git clean on existing repos")
 	cloneCmd.Flags().BoolVar(&prune, "prune", false, "GHORG_PRUNE - remove local clones if not found on remote")
+	cloneCmd.Flags().BoolVar(&pruneNoConfirm, "prune-no-confirm", false, "GHORG_PRUNE_NO_CONFIRM - don't prompt on every prune candidate, just delete")
 	cloneCmd.Flags().BoolVar(&fetchAll, "fetch-all", false, "GHORG_FETCH_ALL - fetches all remote branches for each repo by running a git fetch --all")
 	cloneCmd.Flags().BoolVar(&dryRun, "dry-run", false, "GHORG_DRY_RUN - perform a dry run of the clone; fetches repos but does not clone them")
 	cloneCmd.Flags().BoolVar(&insecureGitlabClient, "insecure-gitlab-client", false, "GHORG_INSECURE_GITLAB_CLIENT - skip TLS certificate verification for hosted gitlab instances")

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -80,24 +80,13 @@ func GetAbsolutePathToCloneTo() string {
 
 // EnsureTrailingSlashOnFilePath takes a filepath and ensures a single / is appened
 func EnsureTrailingSlashOnFilePath(s string) string {
-	trailing := GetCorrectFilePathSeparator()
+	trailing := string(os.PathSeparator)
 
 	if !strings.HasSuffix(s, trailing) {
 		s = s + trailing
 	}
 
 	return s
-}
-
-// GetCorrectFilePathSeparator returns the correct trailing slash based on os
-func GetCorrectFilePathSeparator() string {
-	trailing := "/"
-
-	if runtime.GOOS == "windows" {
-		trailing = "\\"
-	}
-
-	return trailing
 }
 
 // GhorgIgnoreLocation returns the path of users ghorgignore

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -154,6 +154,10 @@ GHORG_DRY_RUN: false
 # flag (--prune)
 GHORG_PRUNE: false
 
+# Skip interactive y/n prompt when pruning clones (only makes sense with --prune).
+# flag (--prune-no-confirm)
+GHORG_PRUNE_NO_CONFIRM: false
+
 # Fetches all remote branches for each repo by running a git fetch --all
 # flag (--fetch-all)
 GHORG_FETCH_ALL: false

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -150,6 +150,10 @@ GHORG_CLONE_WIKI: false
 # flag (--dry-run)
 GHORG_DRY_RUN: false
 
+# Remove locally cloned repos that aren't found on remote (e.g., after remote deletion).  With GHORG_SKIP_ARCHIVED set, archived repositories will also be pruned from your local clone.
+# flag (--prune)
+GHORG_PRUNE: false
+
 # Fetches all remote branches for each repo by running a git fetch --all
 # flag (--fetch-all)
 GHORG_FETCH_ALL: false


### PR DESCRIPTION
## Status
**READY**

I haven't updated any docs.  Let me know if i should.

Also, @gabrie30 mentioned a desire for interactive `y/n` style confirmation.  To be discussed.

## Description

In large organisations where repositories are frequently created and deleted (or archived), i want the possibility for `ghorg clone` to keep my local clone in sync with remote.  In particular, i want the ability to provide a `--prune` flag, which will delete clones that are not found in remote.

This PR provides such a feature, which is *disabled by default*, but can be enabled via `GHORG_PRUNE` or `--prune`.  

Additionally:
* The output of `ghorg clone --dry-run` has been adapted so that if the user opted-in to pruning, the proposed directories to delete are printed out.
* There is (by default) an interactive `(y/N)` prompt before each proposed prune action.  If the user responds anything other than `y` or `yes`, the pruning process is aborted.
* There is a new (off by default) flag `--prune-no-confirm` which skips the `y/n` prompt and just deletes the local clones that don't appear on remote.
* I've removed the helper function `GetCorrectFilePathSeparator` in favour of the simpler `os.PathSeparator` – i don't see how this would change the behaviour.

Closes #205.