### PR TITLE
Fix README installtion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Use ghorg to quickly clone all of an orgs, or users repos into a single director
 
 ## Supported Providers
 - GitHub (Self Hosted & Cloud)
-  - [Install](https://github.com/gabrie30/ghorg#install) | [Setup](https://github.com/gabrie30/ghorg#github-setup) | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/github.md)
+  - [Install](https://github.com/gabrie30/ghorg#installation) | [Setup](https://github.com/gabrie30/ghorg#github-setup) | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/github.md)
 - GitLab (Self Hosted & Cloud)
-  - [Install](https://github.com/gabrie30/ghorg#install) | [Setup](https://github.com/gabrie30/ghorg#gitlab-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/gitlab.md)
+  - [Install](https://github.com/gabrie30/ghorg#installation) | [Setup](https://github.com/gabrie30/ghorg#gitlab-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/gitlab.md)
 - Bitbucket (Cloud Only)
-  - [Install](https://github.com/gabrie30/ghorg#install) | [Setup](https://github.com/gabrie30/ghorg#bitbucket-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/bitbucket.md)
+  - [Install](https://github.com/gabrie30/ghorg#installation) | [Setup](https://github.com/gabrie30/ghorg#bitbucket-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/bitbucket.md)
 - Gitea (Self Hosted Only)
-  - [Install](https://github.com/gabrie30/ghorg#install) | [Setup](https://github.com/gabrie30/ghorg#gitea-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/gitea.md)
+  - [Install](https://github.com/gabrie30/ghorg#installation) | [Setup](https://github.com/gabrie30/ghorg#gitea-setup)  | [Examples](https://github.com/gabrie30/ghorg/blob/master/examples/gitea.md)
 
 > The terminology used in ghorg is that of GitHub, mainly orgs/repos. GitLab and BitBucket use different terminology. There is a handy chart thanks to GitLab that translates terminology [here](https://about.gitlab.com/images/blogimages/gitlab-terminology.png). Note, some features may be different for certain providers.
 


### PR DESCRIPTION


## Status
**READY**

## Description
The link when clicking install leads to nowhere. I think it is meant to point to `Installation`. This PR proposes this!
