### PR TITLE
Request all available top level GitLab groups

### DIFF
--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -84,6 +84,7 @@ func (c Gitlab) GetTopLevelGroups() ([]string, error) {
 			Page:    1,
 		},
 		TopLevelOnly: gitlab.Bool(true),
+		AllAvailable: gitlab.Bool(true),
 	}
 
 	for {


### PR DESCRIPTION
## Status
**READY**

## Description
Request all available top level GitLab groups, not just the ones where the user had some activity in them.

The GitLab api only returns "your groups" by default. If the user tied to the access token didn't interact with the other groups on the GitLab instance, they will not be returned.  
![image](https://user-images.githubusercontent.com/1535823/206026409-d7da106e-0597-49af-a4c3-2bf287f33f5e.png)

This PR makes it so all available top level groups are returned and cloned.
