### PR TITLE
Update gitlab cloud integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [1.9.3] - unreleased
 ### Added
-- Better examples for GitLab; thanks @nudgegoonies
+- Better examples for GitLab
 - Better tests for local gitlab enterprise
 ### Changed
 ### Deprecated
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - gitlab hash concurrency issues
 - all-users command directory nesting
 - ls command to work with output dirs
+- gitlab groups and subgroup nesting; thanks @nudgegoonies
 ### Security
 - Bump github.com/ktrysmt/go-bitbucket from 0.9.54 to 0.9.55
 - Bump github.com/xanzy/go-gitlab from 0.76.0 to 0.77.0

--- a/examples/gitlab.md
+++ b/examples/gitlab.md
@@ -10,7 +10,7 @@ To view all additional flags see the [sample-conf.yaml](https://github.com/gabri
 
 1. The `--preserve-dir` flag will mirror the nested directory structure of the groups/subgroups/projects locally to what is on GitLab. This prevents any name collisions with project names. If this flag is ommited all projects will be cloned into a single directory. If there are collisions with project names and `--preserve-dir` is not used the group/subgroup name will be prepended to those projects. An informational message will also be displayed during the clone to let you know if this happens.
 
-1. For all versions of GitLab you can clone groups or subgroups individually although the behavior is slightly different on hosted vs cloud GitLab
+1. For all versions of GitLab you can clone groups or subgroups.
 
 ## Hosted GitLab Instances
 

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -267,6 +267,9 @@ func (_ Gitlab) addTokenToCloneURL(url string, token string) string {
 
 func (c Gitlab) filter(group string, ps []*gitlab.Project) []Repo {
 	var repoData []Repo
+
+	isSubgroup := strings.Contains(group, "/")
+
 	for _, p := range ps {
 
 		if os.Getenv("GHORG_SKIP_ARCHIVED") == "true" {
@@ -305,7 +308,11 @@ func (c Gitlab) filter(group string, ps []*gitlab.Project) []Repo {
 		// https://github.com/gabrie30/ghorg/issues/228
 		// https://github.com/gabrie30/ghorg/issues/267
 		if !gitLabAllGroups && !gitLabAllUsers {
-			if os.Getenv("GHORG_OUTPUT_DIR") == "" {
+			if isSubgroup {
+				if os.Getenv("GHORG_OUTPUT_DIR") == "" {
+					path = strings.TrimPrefix(path, group)
+				}
+			} else {
 				path = strings.TrimPrefix(path, group)
 			}
 		}

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -305,7 +305,9 @@ func (c Gitlab) filter(group string, ps []*gitlab.Project) []Repo {
 		// https://github.com/gabrie30/ghorg/issues/228
 		// https://github.com/gabrie30/ghorg/issues/267
 		if !gitLabAllGroups && !gitLabAllUsers {
-			path = strings.TrimPrefix(path, group)
+			if os.Getenv("GHORG_OUTPUT_DIR") == "" {
+				path = strings.TrimPrefix(path, group)
+			}
 		}
 
 		r.Path = path

--- a/scripts/gitlab_cloud_integration_tests.sh
+++ b/scripts/gitlab_cloud_integration_tests.sh
@@ -137,9 +137,10 @@ fi
 # OUTPUT DIR AND PRESERVE DIR
 ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir --output-dir=examples-subgroup-preserve-output
 
-if [ -e "${HOME}"/ghorg/examples-subgroup-preserve-output/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
+if [ -e "${HOME}"/ghorg/examples-subgroup-preserve-output/"${GITLAB_GROUP}"/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
 then
     echo "Pass: gitlab subgroup clone preserve directories and output dir"
+    rm -rf "${HOME}/ghorg/examples-subgroup-preserve-output"
 else
     echo "Fail: gitlab subgroup clone preserve directories and output dir"
     exit 1

--- a/scripts/gitlab_cloud_integration_tests.sh
+++ b/scripts/gitlab_cloud_integration_tests.sh
@@ -22,36 +22,61 @@ else
     exit 1
 fi
 
-ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --output-dir=examples --preserve-dir
+#
+# TOP LEVEL GROUP TESTS
+#
 
-if [ -e "${HOME}"/ghorg/examples/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
+# NO FLAGS
+ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab
+
+if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/microservice ]
 then
-    echo "Pass: gitlab org clone preserve directories"
+    echo "Pass: gitlab org clone"
+    rm -rf "${HOME}/ghorg/gitlab-examples"
 else
-    echo "Fail: gitlab org clone preserve directories"
+    echo "Fail: gitlab org clone"
     exit 1
 fi
 
-ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab
+# OUTPUT DIR
+ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --output-dir=examples
 
-if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/"${GITLAB_SUB_GROUP}"/microservice ]
+if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/microservice ]
 then
-    echo "Pass: gitlab subgroup clone flat file"
+    echo "Pass: gitlab org clone output dir"
+    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
 else
-    echo "Fail: gitlab subgroup clone flat file"
+    echo "Fail: gitlab org clone output dir"
     exit 1
 fi
 
-ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir
 
-if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
+# PRESERVE DIR
+ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir
+
+if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/wayne-enterprises/wayne-industries/microservice ]
 then
-    echo "Pass: gitlab subgroup clone preserve directories"
+    echo "Pass: gitlab org clone preserve dir"
+    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
 else
-    echo "Fail: gitlab subgroup clone preserve directories"
+    echo "Fail: gitlab org clone preserve dir"
     exit 1
 fi
 
+
+# OUTPUT DIR AND PRESERVE DIR
+ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir --output-dir=group-output-perserve
+
+if [ -e "${HOME}"/ghorg/group-output-perserve/wayne-enterprises/wayne-industries/microservice ]
+then
+    echo "Pass: gitlab org clone preserve dir, output dir"
+    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
+else
+    echo "Fail: gitlab org clone preserve dir, output dir"
+    exit 1
+fi
+
+# REPO NAME COLLISION
 ghorg clone $GITLAB_GROUP_2 --token="${GITLAB_TOKEN}" --scm=gitlab
 
 if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP_2}"/_subgroup-1_foobar ]
@@ -67,5 +92,55 @@ then
     echo "Pass: gitlab group clone with colliding repo names"
 else
     echo "Fail: gitlab group clone with colliding repo names"
+    exit 1
+fi
+
+#
+# SUBGROUP TESTS
+#
+
+# NO FLAGS
+ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab
+
+if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/"${GITLAB_SUB_GROUP}"/microservice ]
+then
+    echo "Pass: gitlab subgroup clone flat file"
+    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
+else
+    echo "Fail: gitlab subgroup clone flat file"
+    exit 1
+fi
+
+# OUTPUT DIR
+ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --output-dir=example-output
+
+if [ -e "${HOME}"/ghorg/example-output/microservice ]
+then
+    echo "Pass: gitlab subgroup output dir"
+else
+    echo "Fail: gitlab subgroup output dir"
+    exit 1
+fi
+
+# PRESERVE DIR
+ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir
+
+if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
+then
+    echo "Pass: gitlab subgroup clone preserve directories"
+    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
+else
+    echo "Fail: gitlab subgroup clone preserve directories"
+    exit 1
+fi
+
+# OUTPUT DIR AND PRESERVE DIR
+ghorg clone $GITLAB_GROUP/$GITLAB_SUB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --preserve-dir --output-dir=examples-subgroup-preserve-output
+
+if [ -e "${HOME}"/ghorg/examples-subgroup-preserve-output/"${GITLAB_SUB_GROUP}"/wayne-industries/microservice ]
+then
+    echo "Pass: gitlab subgroup clone preserve directories and output dir"
+else
+    echo "Fail: gitlab subgroup clone preserve directories and output dir"
     exit 1
 fi

--- a/scripts/gitlab_cloud_integration_tests.sh
+++ b/scripts/gitlab_cloud_integration_tests.sh
@@ -41,10 +41,10 @@ fi
 # OUTPUT DIR
 ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --output-dir=examples
 
-if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/microservice ]
+if [ -e "${HOME}"/ghorg/examples/microservice ]
 then
     echo "Pass: gitlab org clone output dir"
-    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
+    rm -rf "${HOME}/ghorg/examples"
 else
     echo "Fail: gitlab org clone output dir"
     exit 1

--- a/scripts/local-gitlab/integration-tests.sh
+++ b/scripts/local-gitlab/integration-tests.sh
@@ -282,27 +282,7 @@ fi
 
 rm -rf "${LOCAL_GITLAB_GHORG_DIR}"/local-gitlab-group3
 
-############ CLONE AND TEST SUBGROUP, PRESERVE DIR, OUTPUT DIR ############
-ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-group3-subgroup-a-preserve
-ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-group3-subgroup-a-preserve
-
-GOT=$(ghorg ls local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a | grep -o 'local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3.*')
-WANT=$(cat <<EOF
-local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a/subgroup-b
-local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a/subgroup_a_repo_0
-local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a/subgroup_a_repo_1
-local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a/subgroup_a_repo_2
-local-gitlab-v15-group3-subgroup-a-preserve/local-gitlab-group3/subgroup-a/subgroup_a_repo_3
-EOF
-)
-
-if [ "${WANT}" != "${GOT}" ]
-then
-echo "CLONE AND TEST SUBGROUP, PRESERVE DIR, OUTPUT DIR FAILED"
-exit 1
-fi
-
-############ CLONE AND TEST SUBGROUP, OUTPUT DIR ############
+############ CLONE AND TEST SUBGROUP, NESTED SUBGROUB, OUTPUT DIR ############
 ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --output-dir=local-gitlab-v15-group3-subgroup-a
 ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --output-dir=local-gitlab-v15-group3-subgroup-a
 
@@ -321,7 +301,27 @@ EOF
 
 if [ "${WANT}" != "${GOT}" ]
 then
-echo "CLONE AND TEST SUBGROUP, OUTPUT DIR FAILED"
+echo "CLONE AND TEST SUBGROUP, NESTED SUBGROUB, OUTPUT DIR FAILED"
+exit 1
+fi
+
+############ CLONE AND TEST SUBGROUP, NESTED SUBGROUPS, PRESERVE DIR, OUTPUT DIR ############
+ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-subgroups-preserve-output
+ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-subgroups-preserve-output
+
+GOT=$(ghorg ls local-gitlab-v15-subgroups-preserve-output | grep -o 'local-gitlab-v15-subgroups-preserve-output.*')
+WANT=$(cat <<EOF
+local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup-b
+local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_0
+local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_1
+local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_2
+local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_3
+EOF
+)
+
+if [ "${WANT}" != "${GOT}" ]
+then
+echo "CLONE AND TEST SUBGROUP, NESTED SUBGROUPS, PRESERVE DIR, OUTPUT DIR  FAILED"
 exit 1
 fi
 

--- a/scripts/local-gitlab/integration-tests.sh
+++ b/scripts/local-gitlab/integration-tests.sh
@@ -309,13 +309,13 @@ fi
 ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-subgroups-preserve-output
 ghorg clone local-gitlab-group3/subgroup-a --scm=gitlab --base-url="${GITLAB_URL}" --token="${TOKEN}" --preserve-dir --output-dir=local-gitlab-v15-subgroups-preserve-output
 
-GOT=$(ghorg ls local-gitlab-v15-subgroups-preserve-output | grep -o 'local-gitlab-v15-subgroups-preserve-output.*')
+GOT=$(ghorg ls local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a | grep -o 'local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3.*')
 WANT=$(cat <<EOF
-local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup-b
-local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_0
-local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_1
-local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_2
-local-gitlab-v15-subgroups-preserve-output/subgroup-a/subgroup_a_repo_3
+local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a/subgroup-b
+local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a/subgroup_a_repo_0
+local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a/subgroup_a_repo_1
+local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a/subgroup_a_repo_2
+local-gitlab-v15-subgroups-preserve-output/local-gitlab-group3/subgroup-a/subgroup_a_repo_3
 EOF
 )
 


### PR DESCRIPTION
Update gitlab cloud integration tests. 

Also addresses https://github.com/gabrie30/ghorg/issues/271 -- have decided this behavior does make sense as it gives more context on the subgroup that was cloned when a user clones something like `gitlab-examples/subgroup` using an output dir.