### PR TITLE
Fix Gitea tokens not being found in config.yaml file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -238,6 +238,8 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_RECLONE_PATH")
 	getOrSetDefaults("GHORG_QUIET")
 	getOrSetDefaults("GHORG_GIT_FILTER")
+	getOrSetDefaults("GHORG_GITEA_TOKEN")
+	getOrSetDefaults("GHORG_INSECURE_GITEA_CLIENT")
 
 	if os.Getenv("GHORG_DEBUG") != "" {
 		viper.Debug()

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -169,7 +169,6 @@ func GetOrSetToken() {
 	case "bitbucket":
 		getOrSetBitBucketToken()
 	default:
-		os.Stderr.WriteString("test")
 		getOrSetGiteaToken()
 	}
 }
@@ -232,14 +231,12 @@ func getOrSetBitBucketToken() {
 
 func getOrSetGiteaToken() {
 	var token string
-	os.Stderr.WriteString("Getting in func: " + token + "\n")
 	token = os.Getenv("GHORG_GITEA_TOKEN")
 
 	if isZero(token) || len(token) != 40 {
 		if runtime.GOOS == "windows" {
 			return
 		}
-		os.Stderr.WriteString("Setting in func\n")
 		os.Setenv("GHORG_GITEA_TOKEN", token)
 	}
 }

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -168,6 +168,9 @@ func GetOrSetToken() {
 		getOrSetGitLabToken()
 	case "bitbucket":
 		getOrSetBitBucketToken()
+	default:
+		os.Stderr.WriteString("test")
+		getOrSetGiteaToken()
 	}
 }
 
@@ -224,6 +227,20 @@ func getOrSetBitBucketToken() {
 		} else {
 			os.Setenv("GHORG_BITBUCKET_OAUTH_TOKEN", token)
 		}
+	}
+}
+
+func getOrSetGiteaToken() {
+	var token string
+	os.Stderr.WriteString("Getting in func: " + token + "\n")
+	token = os.Getenv("GHORG_GITEA_TOKEN")
+
+	if isZero(token) || len(token) != 40 {
+		if runtime.GOOS == "windows" {
+			return
+		}
+		os.Stderr.WriteString("Setting in func\n")
+		os.Setenv("GHORG_GITEA_TOKEN", token)
 	}
 }
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
Gitea tokens in the config.yaml are not recognized in the program logic. I changed a few things to make it work, but I am not very familiar with go or with the project as a whole, so please review the changes to make sure the new lines don't break anything or are otherwise in need of extension. It works on my machine now.
