### PR TITLE
Remove token length checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+- Token length checks
 ### Fixed
 - Gitea tokens from not being found in config.yaml; thanks @Antfere
 ### Security

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -175,7 +175,7 @@ func GetOrSetToken() {
 
 func getOrSetGitHubToken() {
 	var token string
-	if isZero(os.Getenv("GHORG_GITHUB_TOKEN")) || len(os.Getenv("GHORG_GITHUB_TOKEN")) != 40 {
+	if isZero(os.Getenv("GHORG_GITHUB_TOKEN")) {
 		if runtime.GOOS == "windows" {
 			return
 		}
@@ -189,15 +189,9 @@ func getOrSetGitHubToken() {
 }
 
 func getOrSetGitLabToken() {
-	var token string
+	token := os.Getenv("GHORG_GITLAB_TOKEN")
 
-	token = os.Getenv("GHORG_GITLAB_TOKEN")
-
-	if strings.HasPrefix(token, "glpat-") && len(token) == 26 {
-		return
-	}
-
-	if isZero(token) || len(token) != 20 {
+	if isZero(token) {
 		if runtime.GOOS == "windows" {
 			return
 		}
@@ -230,10 +224,9 @@ func getOrSetBitBucketToken() {
 }
 
 func getOrSetGiteaToken() {
-	var token string
-	token = os.Getenv("GHORG_GITEA_TOKEN")
+	token := os.Getenv("GHORG_GITEA_TOKEN")
 
-	if isZero(token) || len(token) != 40 {
+	if isZero(token) {
 		if runtime.GOOS == "windows" {
 			return
 		}


### PR DESCRIPTION
## Description

As SCM's change their tokens this check just ends up breaking things and isn't really necessary.
