### PR TITLE
Changed Dockerfile to leverage multi-stage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,55 @@
-FROM golang:alpine
+# ==================================================
+# Build image
+# ==================================================
+FROM golang:alpine AS build-image
 
-# Install dependencies for copy
-RUN apk add -U --no-cache ca-certificates tzdata git
+# ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 
 WORKDIR /go/src/github.com/gabrie30/ghorg
+
 COPY . .
 
-# Fetching dependencies and build the app
 RUN go get -d -v ./... \
-    && CGO_ENABLED=0 go build -a --mod vendor -o ghorg .
+    && go build -a --mod vendor -o ghorg .
 
-# Needed for reclone command
-RUN cp ./ghorg /go/bin/ghorg
+# ==================================================
+# Runtime image
+# ==================================================
+FROM alpine:latest AS runtime-image
+
+ARG USER=ghorg
+ARG GROUP=ghorg
+ARG UID=1111
+ARG GID=2222
+
+ENV XDG_CONFIG_HOME=/config
+ENV GHORG_CONFIG=/config/conf.yaml
+ENV GHORG_RECLONE_PATH=/config/reclone.yaml
+ENV GHORG_ABSOLUTE_PATH_TO_CLONE_TO=/data
+
+RUN apk add -U --no-cache ca-certificates tzdata git \
+    && mkdir -p /data $XDG_CONFIG_HOME \
+    && addgroup --gid $GID $GROUP \
+    && adduser -D -H --gecos "" \
+                     --home "/home" \
+                     --ingroup "$GROUP" \
+                     --uid "$UID" \
+                     "$USER" \
+    && chown -R $USER:$GROUP /home /data $XDG_CONFIG_HOME \
+    && rm -rf /tmp/* /var/{cache,log}/* /var/lib/apt/lists/*
+
+USER $USER
+WORKDIR /data
+
+# Sample config
+COPY --from=build-image --chown=$USER:$GROUP /go/src/github.com/gabrie30/ghorg/sample-conf.yaml /config/conf.yaml
+COPY --from=build-image --chown=$USER:$GROUP /go/src/github.com/gabrie30/ghorg/sample-reclone.yaml /config/reclone.yaml
+
+# Copy compiled binary
+COPY --from=build-image --chown=$USER:$GROUP /go/src/github.com/gabrie30/ghorg/ghorg /usr/local/bin
+
+VOLUME /data
+
+ENTRYPOINT ["ghorg"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ $ ghorg exmaples github
 
 ```bash
 # using your local ghorg configuration file, cloning in container
-docker run -v $HOME/.config/ghorg:/root/.config/ghorg ghorg-docker ghorg clone kubernetes
+docker run -v $HOME/.config/ghorg:/config ghorg-docker clone kubernetes
 
 # using flags, cloning in container
-docker run ghorg-docker ghorg clone kubernetes --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
+docker run ghorg-docker clone kubernetes --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
 
 # using flags, cloning to your machine
-docker run -v $HOME/ghorg/:/root/ghorg/ ghorg-docker ghorg clone kubernetes --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 --output-dir=cloned-from-docker
+docker run -v $HOME/ghorg/:/data ghorg-docker clone kubernetes --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 --output-dir=cloned-from-docker
 ```
 
 ## Changing Clone Directories


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes #352 

There are some functionality changes that I believe improve usage experience:
- No longer needed to pass ghorg to `docker run` command
- If `docker run` is used without a command, it will display `--help`
- Defined two dirs: `/data` (a volume) for the data, `/config` for config files.
- Working dir is `/data`
- Run as `ghorg` user
- Multi-stage builds
- Image size reduced from  ~700 MB to 50 MB
- Automatically adds the sample config files in `/config`, if it's not mounted
- Defines the following env variables by default, but can be overriden at any time with docker's `-e` flags
  - `XDG_CONFIG_HOME=/config`
  - `GHORG_CONFIG=/config/conf.yaml`
  - `GHORG_RECLONE_PATH=/config/reclone.yaml`
  - `GHORG_ABSOLUTE_PATH_TO_CLONE_TO=/data`
 
Did a few updates on README.md, but I'll review and improve that section as part of #351

Some of this edits are ported from [afonsoc12/docker-ghorg](https://github.com/afonsoc12/docker-ghorg) in preparation to decommission that repo
