### PR TITLE
feat: :sparkles: Allow  using file paths in --token and GHORG_*_TOKEN…

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you don't know which to choose its likely going to be the x86_64 version for 
 > Note: if you are running into issues, read the troubleshooting and known issues section below
 
 ### GitHub Setup
-1. Create [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) with all `repo` scopes. Update `GHORG_GITHUB_TOKEN` in your `ghorg/conf.yaml` or as a cli flag. If your org has Saml SSO in front you will need to give your token those permissions as well, see [this doc](https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
+1. Create [Personal Access Token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) with all `repo` scopes. Update `GHORG_GITHUB_TOKEN` in your `ghorg/conf.yaml` or as a cli flag or place it in a file and add the path to `GHORG_GITHUB_TOKEN`. If your org has Saml SSO in front you will need to give your token those permissions as well, see [this doc](https://docs.github.com/en/github/authenticating-to-github/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on).
 1. For cloning GitHub Enterprise (self hosted github instances) repos you must set `--base-url` e.g. `ghorg clone <github_org> --base-url=https://internal.github.com`
 1. See [examples/github.md](https://github.com/gabrie30/ghorg/blob/master/examples/github.md) on how to run
 
@@ -183,14 +183,14 @@ If you don't know which to choose its likely going to be the x86_64 version for 
 ### GitLab Setup
 
 1. Create [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) with the `read_api` scope (or `api` for self-managed GitLab older than 12.10). This token can be added to your `ghorg/conf.yaml` or as a cli flag.
-1. Update the `GitLab Specific` config in your `ghorg/conf.yaml` or via cli flags
+1. Update the `GitLab Specific` config in your `ghorg/conf.yaml` or via cli flags or place it in a file and add the path to `GHORG_GITLAB_TOKEN`
 1. Update `GHORG_SCM_TYPE` to `gitlab` in your `ghorg/conf.yaml` or via cli flags
 1. See [examples/gitlab.md](https://github.com/gabrie30/ghorg/blob/master/examples/gitlab.md) on how to run
 
 ### Gitea Setup
 
 1. Create [Access Token](https://docs.gitea.io/en-us/api-usage/) (Settings -> Applications -> Generate Token)
-1. Update `GHORG_GITEA_TOKEN` in your `ghorg/conf.yaml` or use the (--token, -t) flag.
+1. Update `GHORG_GITEA_TOKEN` in your `ghorg/conf.yaml` or use the (--token, -t) flag or place it in a file and add the path to `GHORG_GITEA_TOKEN`.
 1. Update `GHORG_SCM_TYPE` to `gitea` in your `ghorg/conf.yaml` or via cli flags
 1. See [examples/gitea.md](https://github.com/gabrie30/ghorg/blob/master/examples/gitea.md) on how to run
 
@@ -216,6 +216,8 @@ See [examples](https://github.com/gabrie30/ghorg/tree/master/examples) dir for m
 
 ```bash
 $ ghorg clone kubernetes --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
+# Example how to use --token with a file path
+$ ghorg clone kubernetes --token=~/.config/ghorg/gitlab-token.txt
 $ ghorg clone davecheney --clone-type=user --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
 $ ghorg clone gitlab-examples --scm=gitlab --preserve-dir --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
 $ ghorg clone gitlab-examples/wayne-enterprises --scm=gitlab --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -221,10 +221,14 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 	configs.GetOrSetToken()
 
 	if cmd.Flags().Changed("token") {
+		token := cmd.Flag("token").Value.String()
+		if configs.IsFilePath(token) {
+			token = configs.GetTokenFromFile(token)
+		}
 		if os.Getenv("GHORG_SCM_TYPE") == "github" {
-			os.Setenv("GHORG_GITHUB_TOKEN", cmd.Flag("token").Value.String())
+			os.Setenv("GHORG_GITHUB_TOKEN", token)
 		} else if os.Getenv("GHORG_SCM_TYPE") == "gitlab" {
-			os.Setenv("GHORG_GITLAB_TOKEN", cmd.Flag("token").Value.String())
+			os.Setenv("GHORG_GITLAB_TOKEN", token)
 		} else if os.Getenv("GHORG_SCM_TYPE") == "bitbucket" {
 			if cmd.Flags().Changed("bitbucket-username") {
 				os.Setenv("GHORG_BITBUCKET_APP_PASSWORD", cmd.Flag("token").Value.String())
@@ -232,7 +236,7 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 				os.Setenv("GHORG_BITBUCKET_OAUTH_TOKEN", cmd.Flag("token").Value.String())
 			}
 		} else if os.Getenv("GHORG_SCM_TYPE") == "gitea" {
-			os.Setenv("GHORG_GITEA_TOKEN", cmd.Flag("token").Value.String())
+			os.Setenv("GHORG_GITEA_TOKEN", token)
 		}
 	}
 	err := configs.VerifyTokenSet()

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -157,7 +157,7 @@ GHORG_NO_TOKEN: false
 # +-+-+-+-+-+-+ +-+-+-+-+-+-+-+-+
 
 # Add your GitHub token
-# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
+# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 or --token=~/path/to/file/containing/token
 GHORG_GITHUB_TOKEN:
 
 # Path to your GitHub App PEM file, for authenticating with GitHub App
@@ -178,7 +178,7 @@ GHORG_GITHUB_APP_ID:
 # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 # Add your GitLab token
-# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
+# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 or --token=~/path/to/file/containing/token
 GHORG_GITLAB_TOKEN:
 
 # clones repos in a directory structure that matches gitlab namespaces eg company/unit/subunit/app would clone into ghorg/org/unit/subunit/app
@@ -199,7 +199,7 @@ GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX:
 
 # Add your Gitea token
 # Settings -> Applications -> Generate Token
-# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2
+# flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 or --token=~/path/to/file/containing/token
 GHORG_GITEA_TOKEN:
 
 # Must be present if your gitea instance uses http


### PR DESCRIPTION
… environment variable.

## Status
**READY**

## Description
This feature enables usage of file path's for `--token` and corresponding env vars `GHORG_*_TOKEN`. 

I am by far not a go programming expert, but I testet this feature with the `--token` and the `GHORG_*_TOKEN` environment variable. Either with the token itself and with a path given.

If this feature is ok enough, I will also add documentation.
I am not sure how to write a test for this feature, if someone can guide me, I would also add some tests.

closes #356
