### PR TITLE
Prevent checkout failure on default branch change

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -756,6 +756,25 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 					}
 
 				} else {
+					if os.Getenv("GHORG_FETCH_ALL") == "true" {
+						err = git.FetchAll(repo)
+
+						if err != nil {
+							e := fmt.Sprintf("Could not fetch remotes: %s Error: %v", repo.URL, err)
+							cloneErrors = append(cloneErrors, e)
+							return
+						}
+					} else {
+						err = git.FetchCloneBranch(repo)
+
+						if err != nil {
+							e := fmt.Sprintf("Could not fetch remote: %s Error: %v", repo.URL, err)
+							cloneErrors = append(cloneErrors, e)
+							return
+						}
+					}
+
+
 					err := git.Checkout(repo)
 					if err != nil {
 						e := fmt.Sprintf("Could not checkout out %s, branch may not exist or may not have any contents, no changes made on: %s Error: %v", repo.CloneBranch, repo.URL, err)
@@ -789,16 +808,6 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 
 					action = "pulling"
 					pulledCount++
-
-					if os.Getenv("GHORG_FETCH_ALL") == "true" {
-						err = git.FetchAll(repo)
-
-						if err != nil {
-							e := fmt.Sprintf("Could not fetch remotes: %s Error: %v", repo.URL, err)
-							cloneErrors = append(cloneErrors, e)
-							return
-						}
-					}
 				}
 
 				err = git.SetOrigin(repo)

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -97,6 +97,10 @@ func (g MockGitClient) FetchAll(repo scm.Repo) error {
 	return nil
 }
 
+func (g MockGitClient) FetchCloneBranch(repo scm.Repo) error {
+	return nil
+}
+
 func TestInitialClone(t *testing.T) {
 	defer UnsetEnv("GHORG_")()
 	dir, err := os.MkdirTemp("", "ghorg_test_initial")


### PR DESCRIPTION
## Status
**READY**

## Description

When using ghorg to reclone repos that had a branch change, the checkout step fails because the new branch does not yet exist locally. 
This PR changes the order of actions so a fetch of the clone branch OR a fetch all happens BEFORE the checkout step.