### PR TITLE
Update reclone with better stdout and stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
-## [1.9.14] - unreleased
+## [1.10.00] - unreleased
 ### Added
 - GHORG_NO_DIR_SIZE flag to turn off directory size output which is now enabled by default
 - GHORG_STATS_ENABLED flag to track clone data over time, set to false by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+- GHORG_RECLONE_VERBOSE flag
 ### Fixed
 ### Security
 - Bump code.gitea.io/sdk/gitea from 0.18.0 to 0.19.0 (#441)
@@ -287,7 +288,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Security
 ## [1.8.2] - 7/6/22
 ### Added
-- GHORG_RECLONE_VERBOSE flag
 - GHORG_RECLONE_QUIET flag
 ### Changed
 - reclone logging format

--- a/cmd/reclone.go
+++ b/cmd/reclone.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
@@ -81,10 +80,6 @@ func reCloneFunc(cmd *cobra.Command, argz []string) {
 		os.Exit(0)
 	}
 
-	if !isVerboseReClone() && !isQuietReClone() {
-		asciiTime()
-	}
-
 	if len(argz) == 0 {
 		for _, key := range mapOfReClones {
 			runReClone(key)
@@ -155,7 +150,8 @@ func runReClone(rc ReClone) {
 	safeToLogCmd := sanitizeCmd(strings.Clone(rc.Cmd))
 
 	if !isQuietReClone() {
-		colorlog.PrintInfo(fmt.Sprintf("$ %v", safeToLogCmd))
+		fmt.Println("")
+		colorlog.PrintInfo(fmt.Sprintf("> %v", safeToLogCmd))
 	}
 
 	ghorgClone := exec.Command("ghorg", remainingCommand...)
@@ -184,27 +180,26 @@ func runReClone(rc ReClone) {
 		}
 	}
 
-	stdout, err := ghorgClone.StdoutPipe()
-	if err != nil {
-		colorlog.PrintErrorAndExit(fmt.Sprintf("ERROR: Problem with piping to stdout, err: %v", err))
+	// Connect ghorgClone's stdout and stderr to the current process's stdout and stderr
+	if !isQuietReClone() {
+		ghorgClone.Stdout = os.Stdout
+		ghorgClone.Stderr = os.Stderr
+	} else {
+		spinningSpinner.Start()
+		defer spinningSpinner.Stop()
+		ghorgClone.Stdout = nil
+		ghorgClone.Stderr = nil
 	}
 
-	err = ghorgClone.Start()
-
+	err := ghorgClone.Start()
 	if err != nil {
+		spinningSpinner.Stop()
 		colorlog.PrintErrorAndExit(fmt.Sprintf("ERROR: Starting ghorg clone cmd: %v, err: %v", safeToLogCmd, err))
-	}
-
-	if isVerboseReClone() && !isQuietReClone() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			m := scanner.Text()
-			fmt.Println(m)
-		}
 	}
 
 	err = ghorgClone.Wait()
 	if err != nil {
+		spinningSpinner.Stop()
 		colorlog.PrintErrorAndExit(fmt.Sprintf("ERROR: Running ghorg clone cmd: %v, err: %v", safeToLogCmd, err))
 	}
 }

--- a/cmd/reclone.go
+++ b/cmd/reclone.go
@@ -24,10 +24,6 @@ type ReClone struct {
 	Description string `yaml:"description"`
 }
 
-func isVerboseReClone() bool {
-	return os.Getenv("GHORG_RECLONE_VERBOSE") == "true"
-}
-
 func isQuietReClone() bool {
 	return os.Getenv("GHORG_RECLONE_QUIET") == "true"
 }
@@ -37,10 +33,6 @@ func reCloneFunc(cmd *cobra.Command, argz []string) {
 	if cmd.Flags().Changed("reclone-path") {
 		path := cmd.Flag("reclone-path").Value.String()
 		os.Setenv("GHORG_RECLONE_PATH", path)
-	}
-
-	if cmd.Flags().Changed("verbose") {
-		os.Setenv("GHORG_RECLONE_VERBOSE", "true")
 	}
 
 	if cmd.Flags().Changed("quiet") {
@@ -171,7 +163,7 @@ func runReClone(rc ReClone) {
 			ghorgEnv := strings.HasPrefix(env, "GHORG_")
 
 			// skip global flags and reclone flags which are set in the conf.yaml
-			if env == "GHORG_COLOR" || env == "GHORG_CONFIG" || env == "GHORG_RECLONE_VERBOSE" || env == "GHORG_RECLONE_QUIET" || env == "GHORG_RECLONE_PATH" || env == "GHORG_RECLONE_RUNNING" {
+			if env == "GHORG_COLOR" || env == "GHORG_CONFIG" || env == "GHORG_RECLONE_QUIET" || env == "GHORG_RECLONE_PATH" || env == "GHORG_RECLONE_RUNNING" {
 				continue
 			}
 			if ghorgEnv {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,6 @@ var (
 	insecureGitlabClient         bool
 	insecureGiteaClient          bool
 	fetchAll                     bool
-	ghorgReCloneVerbose          bool
 	ghorgReCloneQuiet            bool
 	ghorgReCloneList             bool
 	ghorgReCloneEnvConfigOnly    bool
@@ -149,8 +148,6 @@ func getOrSetDefaults(envVar string) {
 		case "GHORG_NO_TOKEN":
 			os.Setenv(envVar, "false")
 		case "GHORG_NO_DIR_SIZE":
-			os.Setenv(envVar, "false")
-		case "GHORG_RECLONE_VERBOSE":
 			os.Setenv(envVar, "false")
 		case "GHORG_RECLONE_ENV_CONFIG_ONLY":
 			os.Setenv(envVar, "false")
@@ -246,7 +243,6 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_INSECURE_GITLAB_CLIENT")
 	getOrSetDefaults("GHORG_INSECURE_GITEA_CLIENT")
 	getOrSetDefaults("GHORG_BACKUP")
-	getOrSetDefaults("GHORG_RECLONE_VERBOSE")
 	getOrSetDefaults("GHORG_RECLONE_ENV_CONFIG_ONLY")
 	getOrSetDefaults("GHORG_RECLONE_QUIET")
 	getOrSetDefaults("GHORG_CONCURRENCY")
@@ -349,7 +345,6 @@ func init() {
 	cloneCmd.Flags().StringVarP(&githubAppID, "github-app-id", "", "", "GHORG_GITHUB_APP_ID -  GitHub App ID, for authenticating with GitHub App")
 
 	reCloneCmd.Flags().StringVarP(&ghorgReClonePath, "reclone-path", "", "", "GHORG_RECLONE_PATH - If you want to set a path other than $HOME/.config/ghorg/reclone.yaml for your reclone configuration")
-	reCloneCmd.Flags().BoolVar(&ghorgReCloneVerbose, "verbose", false, "GHORG_RECLONE_VERBOSE - Verbose logging output")
 	reCloneCmd.Flags().BoolVar(&ghorgReCloneQuiet, "quiet", false, "GHORG_RECLONE_QUIET - Quiet logging output")
 	reCloneCmd.Flags().BoolVar(&ghorgReCloneList, "list", false, "Prints reclone commands and optional descriptions to stdout then will exit 0. Does not obsfucate tokens, and is only available as a commandline argument")
 	reCloneCmd.Flags().BoolVar(&ghorgReCloneEnvConfigOnly, "env-config-only", false, "GHORG_RECLONE_ENV_CONFIG_ONLY - Only use environment variables to set the configuration for all reclones.")

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -274,10 +274,6 @@ GHORG_BITBUCKET_USERNAME:
 # flag (--reclone-path)
 GHORG_RECLONE_PATH:
 
-# Get more verbose logging with reclone command
-# flag (--verbose)
-GHORG_RECLONE_VERBOSE: false
-
 # Quiet logging output with reclone command
 # flag (--quiet)
 GHORG_RECLONE_QUIET: false

--- a/scripts/github_cloud_integration_tests.sh
+++ b/scripts/github_cloud_integration_tests.sh
@@ -86,7 +86,7 @@ mv $HOME/.config/ghorg/conf-bak.yaml $HOME/.config/ghorg/conf.yaml
 # hack to allow sed to be ran on both mac and ubuntu
 sed "s/XTOKEN/${GITHUB_TOKEN}/g" $PWD/scripts/testing_confs/reclone-basic.yaml > $PWD/scripts/testing_confs/updated_reclone.yaml
 
-ghorg reclone --reclone-path=$PWD/scripts/testing_confs/updated_reclone.yaml --verbose
+ghorg reclone --reclone-path=$PWD/scripts/testing_confs/updated_reclone.yaml
 
 if [ -e /tmp/testing_reclone_with_tag/$REPO_WITH_TESTING_TOPIC ]
 then


### PR DESCRIPTION
- Update reclone with better stdout and stderr behavior.
- Remove GHORG_RECLONE_VERBOSE the new behavior will be verbose by default if users want no output they can use the `--quiet` flag. This way it will look and behave more like normal clones.