### PR TITLE
Allow github app token created outside of ghorg to be used for https via `GHORG_GITHUB_TOKEN_FROM_GITHUB_APP` setting

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -58,6 +58,10 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_BRANCH", cmd.Flag("branch").Value.String())
 	}
 
+	if cmd.Flags().Changed("github-token-app") {
+		os.Setenv("GHORG_GITHUB_TOKEN_APP", cmd.Flag("github-token-app").Value.String())
+	}
+
 	if cmd.Flags().Changed("github-app-pem-path") {
 		os.Setenv("GHORG_GITHUB_APP_PEM_PATH", cmd.Flag("github-app-pem-path").Value.String())
 	}

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -58,8 +58,8 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_BRANCH", cmd.Flag("branch").Value.String())
 	}
 
-	if cmd.Flags().Changed("github-token-app") {
-		os.Setenv("GHORG_GITHUB_TOKEN_APP", cmd.Flag("github-token-app").Value.String())
+	if cmd.Flags().Changed("github-token-from-github-app") {
+		os.Setenv("GHORG_GITHUB_TOKEN_FROM_GITHUB_APP", cmd.Flag("github-token-from-github-app").Value.String())
 	}
 
 	if cmd.Flags().Changed("github-app-pem-path") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ var (
 	ghorgReCloneQuiet            bool
 	ghorgReCloneList             bool
 	ghorgReCloneEnvConfigOnly    bool
+	githubTokenIsApp             bool
 	noToken                      bool
 	quietMode                    bool
 	noDirSize                    bool
@@ -211,6 +212,8 @@ func getOrSetDefaults(envVar string) {
 			os.Setenv(envVar, "0")
 		case "GHORG_EXIT_CODE_ON_CLONE_ISSUES":
 			os.Setenv(envVar, "1")
+		case "GHORG_GITHUB_TOKEN_APP":
+			os.Setenv(envVar, "false")
 		}
 	} else {
 		s := viper.GetString(envVar)
@@ -301,6 +304,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_TARGET_REPOS_PATH")
 	getOrSetDefaults("GHORG_CLONE_DEPTH")
 	getOrSetDefaults("GHORG_GITHUB_TOKEN")
+	getOrSetDefaults("GHORG_GITHUB_TOKEN_APP")
 	getOrSetDefaults("GHORG_GITHUB_FILTER_LANGUAGE")
 	getOrSetDefaults("GHORG_COLOR")
 	getOrSetDefaults("GHORG_TOPICS")
@@ -388,6 +392,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&exitCodeOnCloneInfos, "exit-code-on-clone-infos", "", "", "GHORG_EXIT_CODE_ON_CLONE_INFOS - Allows you to control the exit code when ghorg runs into a problem (info level message) cloning a repo from the remote. Info messages will appear after a clone is complete, similar to success messages. (default 0)")
 	cloneCmd.Flags().StringVarP(&exitCodeOnCloneIssues, "exit-code-on-clone-issues", "", "", "GHORG_EXIT_CODE_ON_CLONE_ISSUES - Allows you to control the exit code when ghorg runs into a problem (issue level message) cloning a repo from the remote. Issue messages will appear after a clone is complete, similar to success messages (default 1)")
 	cloneCmd.Flags().StringVarP(&gitFilter, "git-filter", "", "", "GHORG_GIT_FILTER - Allows you to pass arguments to git's filter flag. Useful for filtering out binary objects from repos with --git-filter=blob:none, this requires git version 2.19 or greater.")
+	cloneCmd.Flags().BoolVarP(&githubTokenIsApp, "github-token-app", "", false, "GHORG_GITHUB_TOKEN_APP - Indicate that the Github token should be treated as an app token. Needed if you already obtained a github app token outside the context of ghorg.")
 	cloneCmd.Flags().StringVarP(&githubAppPemPath, "github-app-pem-path", "", "", "GHORG_GITHUB_APP_PEM_PATH - Path to your GitHub App PEM file, for authenticating with GitHub App.")
 	cloneCmd.Flags().StringVarP(&githubAppInstallationID, "github-app-installation-id", "", "", "GHORG_GITHUB_APP_INSTALLATION_ID - GitHub App Installation ID, for authenticating with GitHub App.")
 	cloneCmd.Flags().StringVarP(&githubFilterLanguage, "github-filter-language", "", "", "GHORG_GITHUB_FILTER_LANGUAGE - Filter repos by a language. Can be a comma separated value with no spaces.")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ var (
 	ghorgReCloneQuiet            bool
 	ghorgReCloneList             bool
 	ghorgReCloneEnvConfigOnly    bool
-	githubTokenIsApp             bool
+	githubTokenFromGithubApp     bool
 	noToken                      bool
 	quietMode                    bool
 	noDirSize                    bool
@@ -212,7 +212,7 @@ func getOrSetDefaults(envVar string) {
 			os.Setenv(envVar, "0")
 		case "GHORG_EXIT_CODE_ON_CLONE_ISSUES":
 			os.Setenv(envVar, "1")
-		case "GHORG_GITHUB_TOKEN_APP":
+		case "GHORG_GITHUB_TOKEN_FROM_GITHUB_APP":
 			os.Setenv(envVar, "false")
 		}
 	} else {
@@ -304,7 +304,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_TARGET_REPOS_PATH")
 	getOrSetDefaults("GHORG_CLONE_DEPTH")
 	getOrSetDefaults("GHORG_GITHUB_TOKEN")
-	getOrSetDefaults("GHORG_GITHUB_TOKEN_APP")
+	getOrSetDefaults("GHORG_GITHUB_TOKEN_FROM_GITHUB_APP")
 	getOrSetDefaults("GHORG_GITHUB_FILTER_LANGUAGE")
 	getOrSetDefaults("GHORG_COLOR")
 	getOrSetDefaults("GHORG_TOPICS")
@@ -392,7 +392,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&exitCodeOnCloneInfos, "exit-code-on-clone-infos", "", "", "GHORG_EXIT_CODE_ON_CLONE_INFOS - Allows you to control the exit code when ghorg runs into a problem (info level message) cloning a repo from the remote. Info messages will appear after a clone is complete, similar to success messages. (default 0)")
 	cloneCmd.Flags().StringVarP(&exitCodeOnCloneIssues, "exit-code-on-clone-issues", "", "", "GHORG_EXIT_CODE_ON_CLONE_ISSUES - Allows you to control the exit code when ghorg runs into a problem (issue level message) cloning a repo from the remote. Issue messages will appear after a clone is complete, similar to success messages (default 1)")
 	cloneCmd.Flags().StringVarP(&gitFilter, "git-filter", "", "", "GHORG_GIT_FILTER - Allows you to pass arguments to git's filter flag. Useful for filtering out binary objects from repos with --git-filter=blob:none, this requires git version 2.19 or greater.")
-	cloneCmd.Flags().BoolVarP(&githubTokenIsApp, "github-token-app", "", false, "GHORG_GITHUB_TOKEN_APP - Indicate that the Github token should be treated as an app token. Needed if you already obtained a github app token outside the context of ghorg.")
+	cloneCmd.Flags().BoolVarP(&githubTokenFromGithubApp, "github-token-from-github-app", "", false, "GHORG_GITHUB_TOKEN_FROM_GITHUB_APP - Indicate that the Github token should be treated as an app token. Needed if you already obtained a github app token outside the context of ghorg.")
 	cloneCmd.Flags().StringVarP(&githubAppPemPath, "github-app-pem-path", "", "", "GHORG_GITHUB_APP_PEM_PATH - Path to your GitHub App PEM file, for authenticating with GitHub App.")
 	cloneCmd.Flags().StringVarP(&githubAppInstallationID, "github-app-installation-id", "", "", "GHORG_GITHUB_APP_INSTALLATION_ID - GitHub App Installation ID, for authenticating with GitHub App.")
 	cloneCmd.Flags().StringVarP(&githubFilterLanguage, "github-filter-language", "", "", "GHORG_GITHUB_FILTER_LANGUAGE - Filter repos by a language. Can be a comma separated value with no spaces.")

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -203,8 +203,8 @@ GHORG_STATS_ENABLED: false
 GHORG_GITHUB_TOKEN:
 
 # Indicate that the Github token should be treated as an app token. Needed if you already obtained a github app token outside the context of ghorg.
-# flag (--github-token-app)
-GHORG_GITHUB_TOKEN_APP: false
+# flag (--github-token-from-github-app)
+GHORG_GITHUB_TOKEN_FROM_GITHUB_APP: false
 
 # Path to your GitHub App PEM file, for authenticating with GitHub App
 # e.g. /home/user/foo/ghorg-app.pem

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -202,6 +202,10 @@ GHORG_STATS_ENABLED: false
 # flag (--token, -t) eg: --token=bGVhdmUgYSBjb21tZW50IG9uIGlzc3VlIDY2 or --token=~/path/to/file/containing/token
 GHORG_GITHUB_TOKEN:
 
+# Indicate that the Github token should be treated as an app token. Needed if you already obtained a github app token outside the context of ghorg.
+# flag (--github-token-app)
+GHORG_GITHUB_TOKEN_APP: false
+
 # Path to your GitHub App PEM file, for authenticating with GitHub App
 # e.g. /home/user/foo/ghorg-app.pem
 # flag (--github-app-pem-path)

--- a/scm/github.go
+++ b/scm/github.go
@@ -281,7 +281,7 @@ func (c Github) filter(allRepos []*github.Repository) []Repo {
 // Then if https clone method is used the clone url will be https://username:token@github.com/org/repo.git
 // The username is now needed when using the new fine-grained tokens for github
 func (c Github) SetTokensUsername() {
-	if os.Getenv("GHORG_GITHUB_APP_PEM_PATH") != "" {
+	if os.Getenv("GHORG_GITHUB_TOKEN_APP") == "true" || os.Getenv("GHORG_GITHUB_APP_PEM_PATH") != "" {
 		tokenUsername = "x-access-token"
 		return
 	}

--- a/scm/github.go
+++ b/scm/github.go
@@ -281,7 +281,7 @@ func (c Github) filter(allRepos []*github.Repository) []Repo {
 // Then if https clone method is used the clone url will be https://username:token@github.com/org/repo.git
 // The username is now needed when using the new fine-grained tokens for github
 func (c Github) SetTokensUsername() {
-	if os.Getenv("GHORG_GITHUB_TOKEN_APP") == "true" || os.Getenv("GHORG_GITHUB_APP_PEM_PATH") != "" {
+	if os.Getenv("GHORG_GITHUB_TOKEN_FROM_GITHUB_APP") == "true" || os.Getenv("GHORG_GITHUB_APP_PEM_PATH") != "" {
 		tokenUsername = "x-access-token"
 		return
 	}


### PR DESCRIPTION
## Status
**READY**

## Description
In the context of a larger pipeline, I'm running `ghorg` and already have an app token. However, cloning repos via https requires the `x-access-token` username component to be set, and this currently only happens if `ghorg` itself obtained the app token.

I'm honestly not sure whether this is a well-named variable, but `GHORG_GITHUB_TOKEN_IS_AN_APP_TOKEN` seemed a little verbose and out of place, so feedback definitely desired and appreciated!
