### PR TITLE
Use '--' to separate paths from revisions

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -250,7 +250,7 @@ func (g GitClient) ShortStatus(repo scm.Repo) (string, error) {
 }
 
 func (g GitClient) RepoCommitCount(repo scm.Repo) (int, error) {
-	args := []string{"rev-list", "--count", repo.CloneBranch}
+	args := []string{"rev-list", "--count", repo.CloneBranch, "--"}
 	cmd := exec.Command("git", args...)
 	cmd.Dir = repo.HostPath
 


### PR DESCRIPTION
## Status
**READY**

## Description
If a repository has a folder with the same name as the default branch getting post pull commit count fails:
> Problem trying to get post pull commit count for on repo

Fix: Use '--' to separate paths from revisions

fixes #508 