### PR TITLE
Empty repos should not fail on pull

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1032,24 +1032,29 @@ func CloneAllRepos(git git.Gitter, cloneTargets []scm.Repo) {
 		writeGhorgStats(date, allReposToCloneCount, cloneCount, pulledCount, cloneInfosCount, cloneErrorsCount, updateRemoteCount, newCommits, pruneCount, hasCollisions)
 	}
 
-	if os.Getenv("GHORG_EXIT_CODE_ON_CLONE_INFOS") != "0" && cloneInfosCount > 0 {
-		exitCode, err := strconv.Atoi(os.Getenv("GHORG_EXIT_CODE_ON_CLONE_INFOS"))
-		if err != nil {
-			colorlog.PrintError("Could not convert GHORG_EXIT_CODE_ON_CLONE_INFOS from string to integer")
-			os.Exit(1)
-		}
+	if os.Getenv("GHORG_DONT_EXIT_UNDER_TEST") != "true" {
+		if os.Getenv("GHORG_EXIT_CODE_ON_CLONE_INFOS") != "0" && cloneInfosCount > 0 {
+			exitCode, err := strconv.Atoi(os.Getenv("GHORG_EXIT_CODE_ON_CLONE_INFOS"))
+			if err != nil {
+				colorlog.PrintError("Could not convert GHORG_EXIT_CODE_ON_CLONE_INFOS from string to integer")
+				os.Exit(1)
+			}
 
-		os.Exit(exitCode)
+			os.Exit(exitCode)
+		}
 	}
 
-	if cloneErrorsCount > 0 {
-		exitCode, err := strconv.Atoi(os.Getenv("GHORG_EXIT_CODE_ON_CLONE_ISSUES"))
-		if err != nil {
-			colorlog.PrintError("Could not convert GHORG_EXIT_CODE_ON_CLONE_ISSUES from string to integer")
-			os.Exit(1)
+	if os.Getenv("GHORG_DONT_EXIT_UNDER_TEST") != "true" {
+		if cloneErrorsCount > 0 {
+			exitCode, err := strconv.Atoi(os.Getenv("GHORG_EXIT_CODE_ON_CLONE_ISSUES"))
+			if err != nil {
+				colorlog.PrintError("Could not convert GHORG_EXIT_CODE_ON_CLONE_ISSUES from string to integer")
+				os.Exit(1)
+			}
+			os.Exit(exitCode)
 		}
-
-		os.Exit(exitCode)
+	} else {
+		cloneErrorsCount = 0
 	}
 
 }

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -158,6 +158,8 @@ func TestMatchPrefix(t *testing.T) {
 	os.Setenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO", dir)
 	os.Setenv("GHORG_CONCURRENCY", "1")
 	os.Setenv("GHORG_MATCH_PREFIX", "test")
+	os.Setenv("GHORG_DONT_EXIT_UNDER_TEST", "true")
+
 	var testRepos = []scm.Repo{
 		{
 			Name: "testRepoOne",
@@ -195,6 +197,8 @@ func TestExcludeMatchPrefix(t *testing.T) {
 	os.Setenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO", dir)
 	os.Setenv("GHORG_CONCURRENCY", "1")
 	os.Setenv("GHORG_EXCLUDE_MATCH_PREFIX", "test")
+	os.Setenv("GHORG_DONT_EXIT_UNDER_TEST", "true")
+
 	var testRepos = []scm.Repo{
 		{
 			Name: "testRepoOne",
@@ -232,6 +236,8 @@ func TestMatchRegex(t *testing.T) {
 	os.Setenv("GHORG_ABSOLUTE_PATH_TO_CLONE_TO", dir)
 	os.Setenv("GHORG_CONCURRENCY", "1")
 	os.Setenv("GHORG_MATCH_REGEX", "^test-")
+	os.Setenv("GHORG_DONT_EXIT_UNDER_TEST", "true")
+
 	var testRepos = []scm.Repo{
 		{
 			Name: "test-RepoOne",
@@ -271,6 +277,8 @@ func TestExcludeMatchRegex(t *testing.T) {
 	os.Setenv("GHORG_CONCURRENCY", "1")
 	os.Setenv("GHORG_OUTPUT_DIR", testDescriptor)
 	os.Setenv("GHORG_EXCLUDE_MATCH_REGEX", "^test-")
+	os.Setenv("GHORG_DONT_EXIT_UNDER_TEST", "true")
+
 	var testRepos = []scm.Repo{
 		{
 			Name: "test-RepoOne",

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -13,6 +13,7 @@ import (
 func TestShouldLowerRegularString(t *testing.T) {
 
 	upperName := "RepoName"
+	defer setOutputDirName([]string{""})
 	setOutputDirName([]string{upperName})
 
 	if outputDirName != "reponame" {
@@ -23,6 +24,7 @@ func TestShouldLowerRegularString(t *testing.T) {
 func TestShouldNotChangeLowerCasedRegularString(t *testing.T) {
 
 	lowerName := "repo_name"
+	defer setOutputDirName([]string{""})
 	setOutputDirName([]string{lowerName})
 
 	if outputDirName != "repo_name" {
@@ -34,6 +36,7 @@ func TestReplaceDashWithUnderscore(t *testing.T) {
 
 	want := "repo-name"
 	lowerName := "repo-name"
+	defer setOutputDirName([]string{""})
 	setOutputDirName([]string{lowerName})
 
 	if outputDirName != want {
@@ -44,6 +47,7 @@ func TestReplaceDashWithUnderscore(t *testing.T) {
 func TestShouldNotChangeNonLettersString(t *testing.T) {
 
 	numberName := "1234567_8"
+	defer setOutputDirName([]string{""})
 	setOutputDirName([]string{numberName})
 
 	if outputDirName != "1234567_8" {


### PR DESCRIPTION
## Status
**READY**

## Description
If a repository is empty, the initial clone is successful. 

Any subsequent pull fails with the following error message:

> ============ Issues ============
> Could not checkout out main, branch may not exist or may not have any contents/commits, no changes made on: https://github.com/org/repo-name.git Error: exit status 1

Fix: handle empty repositories on pull gracefully.

fixes #502