### PR TITLE
Revert "feat: allow usage of --prune with --preserve-dir"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [1.11.2] - unreleased
 ### Added
-- Prune to work with gitlabs preserve dir; thanks @Fraguinha
 ### Changed
 ### Deprecated
 ### Removed

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -5,7 +5,6 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"fmt"
-	"io/fs"
 	"log"
 	"net/url"
 	"os"
@@ -557,13 +556,7 @@ func printDryRun(repos []scm.Repo) {
 			// to do.
 			colorlog.PrintInfo("\nScanning for local clones that have been removed on remote...")
 
-			var files []os.DirEntry
-			var err error
-			if os.Getenv("GHORG_PRESERVE_DIRECTORY_STRUCTURE") == "true" {
-				files, err = readDirRecursively(outputDirAbsolutePath)
-			} else {
-				files, err = os.ReadDir(outputDirAbsolutePath)
-			}
+			files, err := os.ReadDir(outputDirAbsolutePath)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -604,25 +597,6 @@ func getCloneableInventory(allRepos []scm.Repo) (int, int, int, int) {
 	}
 	total = repos + snippets + wikis
 	return total, repos, snippets, wikis
-}
-
-func isGitRepository(path string) bool {
-	file, err := os.Stat(filepath.Join(path, ".git"))
-	return err == nil && file.IsDir()
-}
-
-func readDirRecursively(name string) ([]os.DirEntry, error) {
-	var files []os.DirEntry
-	err := filepath.WalkDir(name, func(path string, file fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if path != outputDirAbsolutePath && file.IsDir() && isGitRepository(path) {
-			files = append(files, file)
-		}
-		return nil
-	})
-	return files, err
 }
 
 // CloneAllRepos clones all repos
@@ -1320,13 +1294,7 @@ func pruneRepos(cloneTargets []scm.Repo) int {
 	count := 0
 	colorlog.PrintInfo("\nScanning for local clones that have been removed on remote...")
 
-	var files []os.DirEntry
-	var err error
-	if os.Getenv("GHORG_PRESERVE_DIRECTORY_STRUCTURE") == "true" {
-		files, err = readDirRecursively(outputDirAbsolutePath)
-	} else {
-		files, err = os.ReadDir(outputDirAbsolutePath)
-	}
+	files, err := os.ReadDir(outputDirAbsolutePath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1397,7 +1365,14 @@ func interactiveYesNoPrompt(prompt string) bool {
 }
 
 // There's probably a nicer way of finding whether any scm.Repo in the slice matches a given name.
+// TODO, currently this does not work if user sets --preserve-dir see https://github.com/gabrie30/ghorg/issues/210 for more info
 func sliceContainsNamedRepo(haystack []scm.Repo, needle string) bool {
+
+	if os.Getenv("GHORG_PRESERVE_DIRECTORY_STRUCTURE") == "true" {
+		colorlog.PrintError("GHORG_PRUNE (--prune) does not currently work in combination with GHORG_PRESERVE_DIRECTORY_STRUCTURE (--preserve-dir), this will come in later versions")
+		os.Exit(1)
+	}
+
 	for _, repo := range haystack {
 		basepath := filepath.Base(repo.Path)
 

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -524,105 +523,5 @@ func Test_filterDownReposIfTargetReposPathEnabled(t *testing.T) {
 				t.Errorf("filterWithGhorgignore() = %v, want %v", got, tt.expectedResult)
 			}
 		})
-	}
-}
-
-func TestReadDirRecursively(t *testing.T) {
-	dir, err := os.MkdirTemp("", "testing")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	outputDirAbsolutePath = dir
-
-	subDir := filepath.Join(dir, "subdir")
-	if err := os.Mkdir(subDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	gitDir := filepath.Join(subDir, ".git")
-	if err := os.Mkdir(gitDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	files, err := readDirRecursively(dir)
-	if err != nil {
-		t.Fatalf("readDirRecursively returned an error: %v", err)
-	}
-
-	if len(files) != 1 {
-		t.Errorf("Expected %d directories, got %d", 1, len(files))
-	}
-
-	if len(files) > 0 && files[0].Name() != "subdir" {
-		t.Errorf("Expected directory name 'subdir', got '%s'", files[0].Name())
-	}
-}
-
-func TestReadDirRecursivelyNoGitDir(t *testing.T) {
-	dir, err := os.MkdirTemp("", "testing")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	outputDirAbsolutePath = dir
-
-	subDir := filepath.Join(dir, "subdir")
-	if err := os.Mkdir(subDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	files, err := readDirRecursively(dir)
-	if err != nil {
-		t.Fatalf("readDirRecursively returned an error: %v", err)
-	}
-
-	if len(files) != 0 {
-		t.Errorf("Expected %d directories, got %d", 0, len(files))
-	}
-}
-
-func TestReadDirRecursivelyWithGitSubmodule(t *testing.T) {
-	dir, err := os.MkdirTemp("", "testing")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	outputDirAbsolutePath = dir
-
-	subDir := filepath.Join(dir, "subdir")
-	if err := os.Mkdir(subDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	gitDir := filepath.Join(subDir, ".git")
-	if err := os.Mkdir(gitDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	submoduleDir := filepath.Join(subDir, "submodule")
-	if err := os.Mkdir(submoduleDir, 0o755); err != nil {
-		t.Fatalf("Failed to create subdirectory: %v", err)
-	}
-
-	submoduleGitFile := filepath.Join(submoduleDir, ".git")
-	if _, err := os.Create(submoduleGitFile); err != nil {
-		t.Fatalf("Failed to create file: %v", err)
-	}
-
-	files, err := readDirRecursively(dir)
-	if err != nil {
-		t.Fatalf("readDirRecursively returned an error: %v", err)
-	}
-
-	if len(files) != 1 {
-		t.Errorf("Expected %d directories, got %d", 1, len(files))
-	}
-
-	if len(files) > 0 && files[0].Name() != "subdir" {
-		t.Errorf("Expected directory name 'subdir', got '%s'", files[0].Name())
 	}
 }

--- a/scripts/gitlab_cloud_integration_tests.sh
+++ b/scripts/gitlab_cloud_integration_tests.sh
@@ -87,21 +87,6 @@ else
     exit 1
 fi
 
-# PRUNE AND PRESERVE DIR
-ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --prune --preserve-dir
-git init "${HOME}"/ghorg/"${GITLAB_GROUP}"/wayne-enterprises/wayne-industries/prunable
-ghorg clone $GITLAB_GROUP --token="${GITLAB_TOKEN}" --scm=gitlab --prune --preserve-dir
-
-if [ -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/wayne-enterprises/wayne-industries/microservice ] && \
-    [ ! -e "${HOME}"/ghorg/"${GITLAB_GROUP}"/wayne-enterprises/wayne-industries/prunable ]
-then
-    echo "Pass: gitlab org clone preserve dir, prune"
-    rm -rf "${HOME}/ghorg/${GITLAB_GROUP}"
-else
-    echo "Fail: gitlab org clone preserve dir, prune"
-    exit 1
-fi
-
 # REPO NAME COLLISION
 ghorg clone $GITLAB_GROUP_2 --token="${GITLAB_TOKEN}" --scm=gitlab
 


### PR DESCRIPTION
After more testing this isn't working as expected. To get this to work I think the whole pruneRepos function needs to be re-written and use absolute pathing instead of the os.DirEntry, which only has the name.

Reverts gabrie30/ghorg#521