### PR TITLE
Refactor to use 'any' instead of 'interface{}'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Added
 - Self hosted Bitbucket support
 ### Changed
+- Empty interface to any
 ### Deprecated
 ### Removed
 ### Fixed

--- a/cmd/reclone.go
+++ b/cmd/reclone.go
@@ -212,7 +212,6 @@ func runReClone(rc ReClone, rcIdentifier string) {
 		}
 	}
 
-
 	if err != nil {
 		spinningSpinner.Stop()
 		colorlog.PrintErrorAndExit(fmt.Sprintf("ERROR: Running ghorg clone cmd: %v, err: %v", safeToLogCmd, err))

--- a/colorlog/colorlog.go
+++ b/colorlog/colorlog.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PrintInfo prints yellow colored text to standard out
-func PrintInfo(msg interface{}) {
+func PrintInfo(msg any) {
 	if os.Getenv("GHORG_QUIET") == "true" {
 		return
 	}
@@ -23,7 +23,7 @@ func PrintInfo(msg interface{}) {
 }
 
 // PrintSuccess prints green colored text to standard out
-func PrintSuccess(msg interface{}) {
+func PrintSuccess(msg any) {
 	switch os.Getenv("GHORG_COLOR") {
 	case "enabled":
 		color.New(color.FgGreen).Println(msg)
@@ -33,7 +33,7 @@ func PrintSuccess(msg interface{}) {
 }
 
 // PrintError prints red colored text to standard out
-func PrintError(msg interface{}) {
+func PrintError(msg any) {
 	switch os.Getenv("GHORG_COLOR") {
 	case "enabled":
 		color.New(color.FgRed).Println(msg)
@@ -43,7 +43,7 @@ func PrintError(msg interface{}) {
 }
 
 // PrintErrorAndExit prints red colored text to standard out then exits 1
-func PrintErrorAndExit(msg interface{}) {
+func PrintErrorAndExit(msg any) {
 	switch os.Getenv("GHORG_COLOR") {
 	case "enabled":
 		color.New(color.FgRed).Println(msg)
@@ -55,7 +55,7 @@ func PrintErrorAndExit(msg interface{}) {
 }
 
 // PrintSubtleInfo prints magenta colored text to standard out
-func PrintSubtleInfo(msg interface{}) {
+func PrintSubtleInfo(msg any) {
 	if os.Getenv("GHORG_QUIET") == "true" {
 		return
 	}

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -62,7 +62,7 @@ func GetRequiredString(key string) string {
 	return value
 }
 
-func isZero(value interface{}) bool {
+func isZero(value any) bool {
 	return value == reflect.Zero(reflect.TypeOf(value)).Interface()
 }
 

--- a/configs/configs_token_test.go
+++ b/configs/configs_token_test.go
@@ -101,3 +101,4 @@ func TestGetTokenFromFileNonExistent(t *testing.T) {
 	// without changing the implementation. This is a design consideration for future improvement.
 	t.Skip("Skipping test for non-existent file as current implementation calls log.Fatal")
 }
+

--- a/scm/bitbucket.go
+++ b/scm/bitbucket.go
@@ -124,9 +124,9 @@ func (_ Bitbucket) NewClient() (Client, error) {
 
 // Bitbucket Server API structures
 type ServerRepository struct {
-	Name    string                 `json:"name"`
-	Slug    string                 `json:"slug"`
-	Links   map[string]interface{} `json:"links"`
+	Name    string         `json:"name"`
+	Slug    string         `json:"slug"`
+	Links   map[string]any `json:"links"`
 	Project struct {
 		Key string `json:"key"`
 	} `json:"project"`
@@ -249,13 +249,13 @@ func (c Bitbucket) filterServerRepos(repos []ServerRepository) []Repo {
 
 	for _, repo := range repos {
 		if repo.Links != nil && repo.Links["clone"] != nil {
-			cloneLinks, ok := repo.Links["clone"].([]interface{})
+			cloneLinks, ok := repo.Links["clone"].([]any)
 			if !ok {
 				continue
 			}
 
 			for _, linkInterface := range cloneLinks {
-				link, ok := linkInterface.(map[string]interface{})
+				link, ok := linkInterface.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -329,10 +329,10 @@ func (_ Bitbucket) filter(resp []bitbucket.Repository) (repoData []Repo, err err
 	cloneData := []Repo{}
 
 	for _, a := range resp {
-		links := a.Links["clone"].([]interface{})
+		links := a.Links["clone"].([]any)
 		for _, l := range links {
-			link := l.(map[string]interface{})["href"]
-			linkType := l.(map[string]interface{})["name"]
+			link := l.(map[string]any)["href"]
+			linkType := l.(map[string]any)["name"]
 
 			if os.Getenv("GHORG_TOPICS") != "" {
 				colorlog.PrintError("WARNING: Filtering by topics is not supported for Bitbucket SCM")

--- a/scm/filter_test.go
+++ b/scm/filter_test.go
@@ -107,6 +107,6 @@ func TestMatchingTopicsWithMultipleEnvTopics(t *testing.T) {
 			tt.Errorf("Expected %v repo, got: %v", want, got)
 		}
 	})
-	
+
 	os.Setenv("GHORG_TOPICS", "")
 }

--- a/scm/gitea_test.go
+++ b/scm/gitea_test.go
@@ -45,7 +45,7 @@ func setupGiteaTest() (client Gitea, mux *http.ServeMux, serverURL string, teard
 	mux.HandleFunc("/api/v1/settings/api", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		json.NewEncoder(w).Encode(map[string]any{
 			"max_response_items": 50,
 		})
 	})

--- a/scripts/local-bitbucket/seeder/main.go
+++ b/scripts/local-bitbucket/seeder/main.go
@@ -313,7 +313,7 @@ func (b *BitbucketSeeder) createBitbucketServerProject(project *Project) error {
 	}
 
 	// Create project payload
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"key":         project.Key,
 		"name":        project.Name,
 		"description": project.Description,
@@ -372,7 +372,7 @@ func (b *BitbucketSeeder) createBitbucketServerRepository(repo *Repository, proj
 	}
 
 	// Create repository payload
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"name":        repo.Name,
 		"description": repo.Description,
 		"public":      !repo.IsPrivate, // Convert private to public
@@ -479,7 +479,7 @@ Thumbs.db
 	createURL := fmt.Sprintf("%s/rest/api/1.0/projects/%s/repos/%s/browse/.gitignore", b.baseURL, projectKey, repoName)
 
 	// Create form data for file creation
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"content":        gitignoreContent,
 		"message":        "Initial commit: Add .gitignore",
 		"sourceCommitId": "", // Empty for new file

--- a/scripts/local-bitbucket/test-runner/main.go
+++ b/scripts/local-bitbucket/test-runner/main.go
@@ -94,15 +94,15 @@ func (tr *TestRunner) RunAllTests() error {
 
 			// Wait longer before continuing after server health failure
 			if i < len(tr.config.TestScenarios)-1 {
-						log.Printf("⏳ Skipping server recovery wait for faster testing...")
-		// time.Sleep removed
+				log.Printf("⏳ Skipping server recovery wait for faster testing...")
+				// time.Sleep removed
 			}
 			continue
 		}
 
 		// Additional delay before starting test to ensure server stability
-			log.Printf("⏳ Starting test immediately...")
-	time.Sleep(1 * time.Second) // Minimal coordination delay
+		log.Printf("⏳ Starting test immediately...")
+		time.Sleep(1 * time.Second) // Minimal coordination delay
 
 		// Execute the test
 		if err := tr.runTest(&scenario); err != nil {


### PR DESCRIPTION
## Status
Ready

## Description
Replaces instances of 'interface{}' with 'any' throughout the codebase for improved readability and to align with Go 1.18+ conventions. Also includes minor formatting and indentation fixes in test and script files.
