### PR TITLE
Add GitHub repo-list concurrency control

### DIFF
--- a/.github/workflows/gitea-integration-tests.yml
+++ b/.github/workflows/gitea-integration-tests.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.26.0"
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Go dependencies and build the project

--- a/.github/workflows/gitlab-ee-integration-tests.yml
+++ b/.github/workflows/gitlab-ee-integration-tests.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25.0"
+          go-version: "1.26.0"
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install Go dependencies and build the project

--- a/.github/workflows/go-build-test.yml
+++ b/.github/workflows/go-build-test.yml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
-      - name: Set up Go 1.25.0
+      - name: Set up Go 1.26.0
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version: 1.26.0
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -49,10 +49,10 @@ jobs:
     name: Build and Test Windows
     runs-on: windows-latest
     steps:
-      - name: Set up Go 1.25.0
+      - name: Set up Go 1.26.0
         uses: actions/setup-go@v6
         with:
-          go-version: 1.25.0
+          go-version: 1.26.0
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,8 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: "1.26.0"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [1.11.11] - unreleased
 ### Added
 - GHORG_GITHUB_REPO_LIST_CONCURRENCY to prevent github secondary ratelimiting
+- Automatic git clone retries (up to 3 retries with 1s, 2s, then 3s delay) on failure
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [1.11.11] - unreleased
 ### Added
+- GHORG_GITHUB_REPO_LIST_CONCURRENCY to prevent github secondary ratelimiting
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- GitHub Actions use Go 1.26.0 so `go test` matches `go 1.26` and vendored module requirements (was 1.25.0 with `GOTOOLCHAIN=local`)
+
 ### Security
 
 ## [1.11.10] - 3/29/26

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -1446,7 +1446,6 @@ func PrintConfigs() {
 	if os.Getenv("GHORG_CLONE_DEPTH") != "" {
 		colorlog.PrintInfo("* Clone Depth   : " + os.Getenv("GHORG_CLONE_DEPTH"))
 	}
-
 	colorlog.PrintInfo("* Config Used   : " + os.Getenv("GHORG_CONFIG"))
 	if os.Getenv("GHORG_STATS_ENABLED") == "true" {
 		colorlog.PrintInfo("* Stats Enabled : " + os.Getenv("GHORG_STATS_ENABLED"))

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -59,7 +59,7 @@ func shouldAutoAdjustConcurrency() (int, bool, bool) {
 var cloneCmd = &cobra.Command{
 	Use:   "clone [org/user]",
 	Short: "Clone user or org repos from GitHub, GitLab, Gitea or Bitbucket",
-	Long: `Clone user or org repos from GitHub, GitLab, Gitea or Bitbucket. 
+	Long: `Clone user or org repos from GitHub, GitLab, Gitea or Bitbucket.
 
 CONFIGURATION:
   Configuration values are set with the following precedence (highest to lowest):
@@ -137,6 +137,10 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 
 	if cmd.Flags().Changed("github-filter-language") {
 		os.Setenv("GHORG_GITHUB_FILTER_LANGUAGE", cmd.Flag("github-filter-language").Value.String())
+	}
+
+	if cmd.Flags().Changed("github-repo-list-concurrency") {
+		os.Setenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY", cmd.Flag("github-repo-list-concurrency").Value.String())
 	}
 
 	if cmd.Flags().Changed("github-app-id") {
@@ -1362,6 +1366,11 @@ func PrintConfigs() {
 	}
 	if os.Getenv("GHORG_GITHUB_USER_GISTS") == "true" {
 		colorlog.PrintInfo("* Gists         : " + os.Getenv("GHORG_GITHUB_USER_GISTS"))
+	}
+	if strings.EqualFold(os.Getenv("GHORG_SCM_TYPE"), "github") {
+		if ghList := strings.TrimSpace(os.Getenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY")); ghList != "" {
+			colorlog.PrintInfo("* Concurrency   : " + ghList + " max concurrent API pages")
+		}
 	}
 	if configs.GhorgIgnoreDetected() {
 		colorlog.PrintInfo("* Ghorgignore   : " + configs.GhorgIgnoreLocation())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,7 @@ var (
 	githubAppInstallationID      string
 	githubUserOption             string
 	githubFilterLanguage         string
+	githubRepoListConcurrency    string
 	cronTimerMinutes             string
 	recloneServerPort            string
 	cloneDelaySeconds            string
@@ -337,6 +338,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_GITHUB_TOKEN_FROM_GITHUB_APP")
 	getOrSetDefaults("GHORG_GITHUB_USER_GISTS")
 	getOrSetDefaults("GHORG_GITHUB_FILTER_LANGUAGE")
+	getOrSetDefaults("GHORG_GITHUB_REPO_LIST_CONCURRENCY")
 	getOrSetDefaults("GHORG_COLOR")
 	getOrSetDefaults("GHORG_TOPICS")
 	getOrSetDefaults("GHORG_GITLAB_TOKEN")
@@ -441,6 +443,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&githubAppPemPath, "github-app-pem-path", "", "", "GHORG_GITHUB_APP_PEM_PATH - GitHub only: Path to GitHub App private key (.pem file) for app-based authentication. Requires --github-app-id and --github-app-installation-id")
 	cloneCmd.Flags().StringVarP(&githubAppInstallationID, "github-app-installation-id", "", "", "GHORG_GITHUB_APP_INSTALLATION_ID - GitHub only: Installation ID for GitHub App authentication. Find in org settings URL")
 	cloneCmd.Flags().StringVarP(&githubFilterLanguage, "github-filter-language", "", "", "GHORG_GITHUB_FILTER_LANGUAGE - GitHub only: Filter repositories by programming language. Comma-separated values (e.g., --github-filter-language=go,python)")
+	cloneCmd.Flags().StringVarP(&githubRepoListConcurrency, "github-repo-list-concurrency", "", "", "GHORG_GITHUB_REPO_LIST_CONCURRENCY - GitHub only: Max concurrent REST requests when listing org/user repos (API pagination). If unset, all pages are fetched in parallel (fastest; may hit GitHub secondary rate limits on huge orgs). Set to a lower number (e.g. 8 or 1) to throttle listing. Separate from GHORG_CONCURRENCY (git clones only).")
 	cloneCmd.Flags().StringVarP(&githubUserOption, "github-user-option", "", "", "GHORG_GITHUB_USER_OPTION - GitHub only: When using --clone-type=user, specify which repos to include: 'all', 'owner' (created by user), or 'member' (contributed to). (default: owner)")
 	cloneCmd.Flags().StringVarP(&githubAppID, "github-app-id", "", "", "GHORG_GITHUB_APP_ID - GitHub only: GitHub App ID for app-based authentication. Required with --github-app-pem-path")
 	cloneCmd.Flags().StringVar(&sshHostname, "ssh-hostname", "", "GHORG_SSH_HOSTNAME - Custom hostname to use in SSH clone URLs. Useful for SSH aliases in ~/.ssh/config (e.g., --ssh-hostname=my-github-alias creates git@my-github-alias:org/repo.git URLs)")

--- a/git/git.go
+++ b/git/git.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gabrie30/ghorg/scm"
@@ -85,7 +86,7 @@ func (g GitClient) HasRemoteHeads(repo scm.Repo) (bool, error) {
 
 }
 
-func (g GitClient) Clone(repo scm.Repo) error {
+func cloneGitArgs(repo scm.Repo) []string {
 	args := []string{"clone", repo.CloneURL, repo.HostPath}
 
 	if os.Getenv("GHORG_INCLUDE_SUBMODULES") == "true" {
@@ -109,15 +110,34 @@ func (g GitClient) Clone(repo scm.Repo) error {
 	if os.Getenv("GHORG_BACKUP") == "true" {
 		args = append(args, "--mirror")
 	}
+	return args
+}
 
-	cmd := exec.Command("git", args...)
+// cloneRetryDelays are sleeps before each retry after a failed git clone (three retries, two attempts total).
+var cloneRetryDelays = []time.Duration{1 * time.Second}
+
+func (g GitClient) Clone(repo scm.Repo) error {
+	args := cloneGitArgs(repo)
 
 	if os.Getenv("GHORG_DEBUG") != "" {
+		cmd := exec.Command("git", args...)
 		return printDebugCmd(cmd, repo)
 	}
 
-	err := cmd.Run()
-	return err
+	maxAttempts := 1 + len(cloneRetryDelays)
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			_ = os.RemoveAll(repo.HostPath)
+			time.Sleep(cloneRetryDelays[attempt-1])
+		}
+		cmd := exec.Command("git", args...)
+		lastErr = cmd.Run()
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
 }
 
 func (g GitClient) SetOriginWithCredentials(repo scm.Repo) error {

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -302,6 +302,13 @@ GHORG_GITHUB_USER_GISTS: false
 # falg (--github-filter-language) e.g.: --github-filter-language=go,ruby,elixir
 GHORG_GITHUB_FILTER_LANGUAGE:
 
+# Optional: max concurrent GitHub REST requests while listing org/user repos (pagination only).
+# If unset or empty, ghorg lists all pages in parallel (fastest; very large orgs may hit GitHub secondary rate limits).
+# Set to a number (e.g. 8 or 1) to throttle listing when you see rate-limit errors.
+# This is NOT GHORG_CONCURRENCY: that setting only controls parallel git clones after the repo list is built.
+# flag (--github-repo-list-concurrency)
+GHORG_GITHUB_REPO_LIST_CONCURRENCY:
+
 # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 # |G|I|T|L|A|B| |S|P|E|C|I|F|I|C|
 # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/scm/github_list.go
+++ b/scm/github_list.go
@@ -1,0 +1,182 @@
+package scm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gabrie30/ghorg/colorlog"
+	"github.com/google/go-github/v72/github"
+)
+
+const (
+	// maxGithubRepoListConcurrency caps GHORG_GITHUB_REPO_LIST_CONCURRENCY when set (typo guard).
+	maxGithubRepoListConcurrency = 1024
+	maxGithubRepoListRetries     = 6
+	// githubRateLimitLogMinWait: detailed rate-limit logs only if backoff exceeds this.
+	githubRateLimitLogMinWait = 30 * time.Second
+)
+
+// githubListWorkerCount returns how many concurrent workers to use for
+// paginated GitHub repo listing (pages beyond the first). If
+// GHORG_GITHUB_REPO_LIST_CONCURRENCY is unset or empty, all extra pages are
+// listed in parallel (historical ghorg behavior). If set to a positive
+// integer, at most that many list requests run at once.
+func githubListWorkerCount(extraPages int) int {
+	if extraPages < 1 {
+		return 1
+	}
+	s := strings.TrimSpace(os.Getenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY"))
+	if s == "" {
+		return extraPages
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return extraPages
+	}
+	if n > maxGithubRepoListConcurrency {
+		n = maxGithubRepoListConcurrency
+	}
+	if n > extraPages {
+		return extraPages
+	}
+	return n
+}
+
+func isGitHubListRateLimitError(err error) bool {
+	var abuse *github.AbuseRateLimitError
+	var primary *github.RateLimitError
+	return errors.As(err, &abuse) || errors.As(err, &primary)
+}
+
+func formatGithubRateLimitWait(d time.Duration) string {
+	d = d.Round(time.Second)
+	if d < time.Minute {
+		s := int(d.Seconds())
+		if s <= 1 {
+			return "about 1 second"
+		}
+		return fmt.Sprintf("about %d seconds", s)
+	}
+	m := int(d.Minutes())
+	s := int(d.Seconds()) % 60
+	if s == 0 {
+		return fmt.Sprintf("about %d minute(s)", m)
+	}
+	return fmt.Sprintf("about %d minute(s) and %d seconds", m, s)
+}
+
+func truncateForLog(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+// logGithubRateLimitWait tells the user why ghorg is pausing and for how long.
+func logGithubRateLimitWait(attempt int, err error, wait time.Duration, waitCappedToMax bool) {
+	nextAttempt := attempt + 2
+	waitHuman := formatGithubRateLimitWait(wait)
+	detail := truncateForLog(strings.TrimSpace(err.Error()), 400)
+
+	var abuse *github.AbuseRateLimitError
+	var primary *github.RateLimitError
+	switch {
+	case errors.As(err, &abuse):
+		colorlog.PrintInfo("\nGhorg: GitHub rate limited the request used to list your repositories (REST API pagination — this is separate from GHORG_CONCURRENCY, which only affects git clones).")
+		colorlog.PrintInfo("Reason: secondary rate limit (GitHub anti-abuse / scraping protection). Too many list requests happened too quickly for this token or IP.")
+		colorlog.PrintInfo(fmt.Sprintf("Action: waiting %s, then retrying (next list request will be attempt %d of %d).", waitHuman, nextAttempt, maxGithubRepoListRetries))
+		if waitCappedToMax {
+			colorlog.PrintInfo("Note: this wait is capped at 5 minutes per pause; if GitHub still returns a rate limit, ghorg will log again and wait before the following retry.")
+		}
+		colorlog.PrintInfo("How to reduce this: set a lower GHORG_GITHUB_REPO_LIST_CONCURRENCY (try 4 or 1 for fully sequential listing), or use flag --github-repo-list-concurrency=4. If it persists, wait a few minutes before running ghorg again.")
+		colorlog.PrintInfo("If several identical messages appear together, multiple list requests hit the limit in parallel—lowering GHORG_GITHUB_REPO_LIST_CONCURRENCY reduces that.")
+		colorlog.PrintInfo("Reference: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api")
+		if detail != "" {
+			colorlog.PrintInfo("GitHub response: " + detail)
+		}
+	case errors.As(err, &primary):
+		reset := primary.Rate.Reset.UTC().Format(time.RFC3339)
+		colorlog.PrintInfo("Ghorg: GitHub rate limited the request used to list your repositories (REST API pagination — this is separate from GHORG_CONCURRENCY, which only affects git clones).")
+		colorlog.PrintInfo("Reason: primary REST API rate limit for this token (hourly request budget). Listing paused until the limit window resets.")
+		if waitCappedToMax {
+			colorlog.PrintInfo(fmt.Sprintf("Action: waiting %s before the next list request (attempt %d of %d). This pause is capped at 5 minutes per wait; GitHub indicates your token resets around %s UTC — if the next request is still limited, ghorg will wait again and log it.", waitHuman, nextAttempt, maxGithubRepoListRetries, reset))
+		} else {
+			colorlog.PrintInfo(fmt.Sprintf("Action: waiting %s (aligned with GitHub reset ~%s UTC), then retrying (next list request will be attempt %d of %d).", waitHuman, reset, nextAttempt, maxGithubRepoListRetries))
+		}
+		colorlog.PrintInfo("How to reduce this: wait until after the reset time, avoid running other heavy GitHub API clients on the same token at the same time, and/or lower GHORG_GITHUB_REPO_LIST_CONCURRENCY to fetch pages less aggressively.")
+		colorlog.PrintInfo("Reference: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api")
+		if detail != "" {
+			colorlog.PrintInfo("GitHub response: " + detail)
+		}
+	default:
+		colorlog.PrintInfo("Ghorg: GitHub rate limited repository listing. Waiting " + waitHuman + " before retry.")
+		if waitCappedToMax {
+			colorlog.PrintInfo("Note: this wait is capped at 5 minutes per pause; ghorg may log and wait again if limits continue.")
+		}
+		if detail != "" {
+			colorlog.PrintInfo("GitHub response: " + detail)
+		}
+	}
+}
+
+func sleepForGitHubRateLimit(ctx context.Context, attempt int, err error) error {
+	var wait time.Duration
+	var abuse *github.AbuseRateLimitError
+	var primary *github.RateLimitError
+	switch {
+	case errors.As(err, &abuse):
+		if abuse.RetryAfter != nil && *abuse.RetryAfter > 0 {
+			wait = *abuse.RetryAfter
+		} else {
+			wait = time.Duration(30*(attempt+1)) * time.Second
+		}
+	case errors.As(err, &primary):
+		wait = time.Until(primary.Rate.Reset.Time) + 2*time.Second
+		if wait < time.Second {
+			wait = time.Second
+		}
+	}
+	if wait <= 0 {
+		wait = time.Second
+	}
+	const maxWait = 5 * time.Minute
+	waitCapped := false
+	if wait > maxWait {
+		wait = maxWait
+		waitCapped = true
+	}
+	if wait > githubRateLimitLogMinWait {
+		logGithubRateLimitWait(attempt, err, wait, waitCapped)
+	}
+	t := time.NewTimer(wait)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// fetchGitHubRepoPageWithRetry calls fetch until success or a non–rate-limit
+// error, or retries are exhausted.
+func fetchGitHubRepoPageWithRetry(ctx context.Context, fetch func(context.Context) ([]*github.Repository, error)) ([]*github.Repository, error) {
+	for attempt := 0; attempt < maxGithubRepoListRetries; attempt++ {
+		repos, err := fetch(ctx)
+		if err == nil {
+			return repos, nil
+		}
+		if !isGitHubListRateLimitError(err) || attempt == maxGithubRepoListRetries-1 {
+			return nil, err
+		}
+		if err := sleepForGitHubRateLimit(ctx, attempt, err); err != nil {
+			return nil, err
+		}
+	}
+	panic("unreachable: github list retries")
+}

--- a/scm/github_list_test.go
+++ b/scm/github_list_test.go
@@ -1,0 +1,48 @@
+package scm
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGithubListWorkerCount(t *testing.T) {
+	t.Run("zero extra pages", func(t *testing.T) {
+		os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY")
+		if w := githubListWorkerCount(0); w != 1 {
+			t.Fatalf("want 1, got %d", w)
+		}
+	})
+	t.Run("unlimited when env unset", func(t *testing.T) {
+		os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY")
+		if w := githubListWorkerCount(100); w != 100 {
+			t.Fatalf("want 100 (one worker per page), got %d", w)
+		}
+	})
+	t.Run("honors explicit limit", func(t *testing.T) {
+		os.Setenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY", "3")
+		t.Cleanup(func() { os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY") })
+		if w := githubListWorkerCount(10); w != 3 {
+			t.Fatalf("want 3, got %d", w)
+		}
+		if w := githubListWorkerCount(1); w != 1 {
+			t.Fatalf("want 1, got %d", w)
+		}
+	})
+	t.Run("invalid env behaves like unlimited", func(t *testing.T) {
+		os.Setenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY", "nope")
+		t.Cleanup(func() { os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY") })
+		if w := githubListWorkerCount(7); w != 7 {
+			t.Fatalf("want 7, got %d", w)
+		}
+	})
+	t.Run("caps explicit value", func(t *testing.T) {
+		os.Setenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY", "9999")
+		t.Cleanup(func() { os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY") })
+		if w := githubListWorkerCount(10); w != 10 {
+			t.Fatalf("want min(capped, extraPages)=10, got %d", w)
+		}
+		if w := githubListWorkerCount(800); w != maxGithubRepoListConcurrency {
+			t.Fatalf("want %d, got %d", maxGithubRepoListConcurrency, w)
+		}
+	})
+}

--- a/scm/github_list_test.go
+++ b/scm/github_list_test.go
@@ -41,8 +41,12 @@ func TestGithubListWorkerCount(t *testing.T) {
 		if w := githubListWorkerCount(10); w != 10 {
 			t.Fatalf("want min(capped, extraPages)=10, got %d", w)
 		}
-		if w := githubListWorkerCount(800); w != maxGithubRepoListConcurrency {
-			t.Fatalf("want %d, got %d", maxGithubRepoListConcurrency, w)
+		// Capped to maxGithubRepoListConcurrency, but never more workers than pages.
+		if w := githubListWorkerCount(800); w != 800 {
+			t.Fatalf("want min(%d,800)=800, got %d", maxGithubRepoListConcurrency, w)
+		}
+		if w := githubListWorkerCount(maxGithubRepoListConcurrency + 100); w != maxGithubRepoListConcurrency {
+			t.Fatalf("want capped limit %d, got %d", maxGithubRepoListConcurrency, w)
 		}
 	})
 }

--- a/scm/github_parallel.go
+++ b/scm/github_parallel.go
@@ -8,47 +8,55 @@ import (
 	"github.com/google/go-github/v72/github"
 )
 
-// fetchOrgReposParallel fetches remaining pages of org repos concurrently
+// fetchOrgReposParallel fetches remaining pages of org repos with bounded
+// concurrency to avoid GitHub secondary (abuse) rate limits.
 func (c Github) fetchOrgReposParallel(targetOrg string, firstPageRepos []*github.Repository, lastPage int) ([]Repo, error) {
-	// Create slice to hold all repos with capacity for efficiency
 	allRepos := make([]*github.Repository, 0, len(firstPageRepos)*lastPage)
 	allRepos = append(allRepos, firstPageRepos...)
 
-	// Channel to collect results from parallel fetches
 	type pageResult struct {
 		repos []*github.Repository
 		err   error
 		page  int
 	}
-	resultChan := make(chan pageResult, lastPage-1)
-
-	// WaitGroup to track goroutines
-	var wg sync.WaitGroup
-
-	// Fetch pages 2 through lastPage in parallel
-	for page := 2; page <= lastPage; page++ {
-		wg.Add(1)
-		go func(pageNum int) {
-			defer wg.Done()
-
-			opt := &github.RepositoryListByOrgOptions{
-				Type:        "all",
-				ListOptions: github.ListOptions{PerPage: c.perPage, Page: pageNum},
-			}
-
-			repos, _, err := c.Repositories.ListByOrg(context.Background(), targetOrg, opt)
-			resultChan <- pageResult{repos: repos, err: err, page: pageNum}
-		}(page)
+	extra := lastPage - 1
+	if extra < 1 {
+		return c.filter(allRepos), nil
 	}
 
-	// Close channel when all goroutines complete
+	workers := githubListWorkerCount(extra)
+	resultChan := make(chan pageResult, extra)
+	jobs := make(chan int, extra)
+	for p := 2; p <= lastPage; p++ {
+		jobs <- p
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for pageNum := range jobs {
+				repos, err := fetchGitHubRepoPageWithRetry(context.Background(), func(ctx context.Context) ([]*github.Repository, error) {
+					opt := &github.RepositoryListByOrgOptions{
+						Type:        "all",
+						ListOptions: github.ListOptions{PerPage: c.perPage, Page: pageNum},
+					}
+					r, _, e := c.Repositories.ListByOrg(ctx, targetOrg, opt)
+					return r, e
+				})
+				resultChan <- pageResult{repos: repos, err: err, page: pageNum}
+			}
+		}()
+	}
+
 	go func() {
 		wg.Wait()
 		close(resultChan)
 	}()
 
-	// Collect results, organized by page number for consistent ordering
-	pageResults := make(map[int][]*github.Repository, lastPage-1)
+	pageResults := make(map[int][]*github.Repository, extra)
 	for result := range resultChan {
 		if result.err != nil {
 			return nil, result.err
@@ -56,7 +64,6 @@ func (c Github) fetchOrgReposParallel(targetOrg string, firstPageRepos []*github
 		pageResults[result.page] = result.repos
 	}
 
-	// Append results in page order to maintain consistency
 	for page := 2; page <= lastPage; page++ {
 		if repos, ok := pageResults[page]; ok {
 			allRepos = append(allRepos, repos...)
@@ -66,71 +73,81 @@ func (c Github) fetchOrgReposParallel(targetOrg string, firstPageRepos []*github
 	return c.filter(allRepos), nil
 }
 
-// fetchUserReposParallel fetches remaining pages of user repos concurrently
+// fetchUserReposParallel fetches remaining pages of user repos with bounded
+// concurrency to avoid GitHub secondary (abuse) rate limits.
 func (c Github) fetchUserReposParallel(targetUser string, firstPageRepos []*github.Repository, lastPage int) ([]Repo, error) {
-	// Create slice to hold all repos with capacity for efficiency
 	allRepos := make([]*github.Repository, 0, len(firstPageRepos)*lastPage)
 	allRepos = append(allRepos, firstPageRepos...)
 
-	// Channel to collect results from parallel fetches
 	type pageResult struct {
 		repos []*github.Repository
 		err   error
 		page  int
 	}
-	resultChan := make(chan pageResult, lastPage-1)
-
-	// WaitGroup to track goroutines
-	var wg sync.WaitGroup
-
-	// Fetch pages 2 through lastPage in parallel
-	for page := 2; page <= lastPage; page++ {
-		wg.Add(1)
-		go func(pageNum int) {
-			defer wg.Done()
-
-			opt := &github.ListOptions{PerPage: c.perPage, Page: pageNum}
-
-			var repos []*github.Repository
-			var err error
-
-			if targetUser == tokenUsername {
-				authOpt := &github.RepositoryListByAuthenticatedUserOptions{
-					Type:        os.Getenv("GHORG_GITHUB_USER_OPTION"),
-					ListOptions: *opt,
-				}
-				repos, _, err = c.Repositories.ListByAuthenticatedUser(context.Background(), authOpt)
-			} else {
-				userOpt := &github.RepositoryListByUserOptions{
-					Type:        os.Getenv("GHORG_GITHUB_USER_OPTION"),
-					ListOptions: *opt,
-				}
-				repos, _, err = c.Repositories.ListByUser(context.Background(), targetUser, userOpt)
-			}
-
-			// Filter user repos if needed
-			if targetUser != tokenUsername && err == nil {
-				userRepos := []*github.Repository{}
-				for _, repo := range repos {
-					if repo.Owner != nil && repo.Owner.Type != nil && *repo.Owner.Type == "User" {
-						userRepos = append(userRepos, repo)
-					}
-				}
-				repos = userRepos
-			}
-
-			resultChan <- pageResult{repos: repos, err: err, page: pageNum}
-		}(page)
+	extra := lastPage - 1
+	if extra < 1 {
+		return c.filter(allRepos), nil
 	}
 
-	// Close channel when all goroutines complete
+	workers := githubListWorkerCount(extra)
+	resultChan := make(chan pageResult, extra)
+	jobs := make(chan int, extra)
+	for p := 2; p <= lastPage; p++ {
+		jobs <- p
+	}
+	close(jobs)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for pageNum := range jobs {
+				repos, err := fetchGitHubRepoPageWithRetry(context.Background(), func(ctx context.Context) ([]*github.Repository, error) {
+					opt := &github.ListOptions{PerPage: c.perPage, Page: pageNum}
+
+					var r []*github.Repository
+					var e error
+
+					if targetUser == tokenUsername {
+						authOpt := &github.RepositoryListByAuthenticatedUserOptions{
+							Type:        os.Getenv("GHORG_GITHUB_USER_OPTION"),
+							ListOptions: *opt,
+						}
+						r, _, e = c.Repositories.ListByAuthenticatedUser(ctx, authOpt)
+					} else {
+						userOpt := &github.RepositoryListByUserOptions{
+							Type:        os.Getenv("GHORG_GITHUB_USER_OPTION"),
+							ListOptions: *opt,
+						}
+						r, _, e = c.Repositories.ListByUser(ctx, targetUser, userOpt)
+					}
+					if e != nil {
+						return nil, e
+					}
+
+					if targetUser != tokenUsername {
+						userRepos := []*github.Repository{}
+						for _, repo := range r {
+							if repo.Owner != nil && repo.Owner.Type != nil && *repo.Owner.Type == "User" {
+								userRepos = append(userRepos, repo)
+							}
+						}
+						r = userRepos
+					}
+					return r, nil
+				})
+				resultChan <- pageResult{repos: repos, err: err, page: pageNum}
+			}
+		}()
+	}
+
 	go func() {
 		wg.Wait()
 		close(resultChan)
 	}()
 
-	// Collect results, organized by page number for consistent ordering
-	pageResults := make(map[int][]*github.Repository, lastPage-1)
+	pageResults := make(map[int][]*github.Repository, extra)
 	for result := range resultChan {
 		if result.err != nil {
 			return nil, result.err
@@ -138,7 +155,6 @@ func (c Github) fetchUserReposParallel(targetUser string, firstPageRepos []*gith
 		pageResults[result.page] = result.repos
 	}
 
-	// Append results in page order to maintain consistency
 	for page := 2; page <= lastPage; page++ {
 		if repos, ok := pageResults[page]; ok {
 			allRepos = append(allRepos, repos...)

--- a/scm/github_test.go
+++ b/scm/github_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	ghpkg "github.com/google/go-github/v72/github"
 )
@@ -340,5 +342,79 @@ func TestFilterGistsCollisions(t *testing.T) {
 	// No collision for "unique"
 	if got := names["ccc333"]; got != "unique" {
 		t.Errorf("ccc333: expected 'unique', got %q", got)
+	}
+}
+
+func TestGetOrgRepos_MultiPageRespectsListConcurrency(t *testing.T) {
+	mux := http.NewServeMux()
+	var mu sync.Mutex
+	inFlight, maxInFlight := 0, 0
+
+	mux.HandleFunc("/orgs/conctest/repos", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+		defer func() {
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+		}()
+
+		time.Sleep(20 * time.Millisecond)
+
+		page := r.URL.Query().Get("page")
+		if page == "" {
+			page = "1"
+		}
+		if page == "1" {
+			per := r.URL.Query().Get("per_page")
+			if per == "" {
+				per = "100"
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<https://example.invalid/repos?page=2&per_page=%s>; rel="next", <https://example.invalid/repos?page=4&per_page=%s>; rel="last"`, per, per))
+		}
+		fmt.Fprintf(w, `[{"id":%s,"name":"repo-p%s","clone_url":"https://github.com/o/r%s.git","ssh_url":"git@github.com:o/r%s.git","archived":false,"fork":false,"topics":[],"default_branch":"main"}]`, page, page, page, page)
+	})
+
+	apiHandler := http.NewServeMux()
+	apiHandler.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
+	apiHandler.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		http.Error(w, "unexpected request "+req.URL.String(), http.StatusInternalServerError)
+	})
+
+	server := httptest.NewServer(apiHandler)
+	defer server.Close()
+
+	client := ghpkg.NewClient(nil)
+	u, _ := url.Parse(server.URL + baseURLPath + "/")
+	client.BaseURL = u
+	client.UploadURL = u
+
+	gh := Github{Client: client}
+
+	os.Setenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY", "2")
+	os.Setenv("GHORG_CLONE_PROTOCOL", "https")
+	os.Setenv("GHORG_GITHUB_TOKEN", "tok")
+	defer func() {
+		os.Unsetenv("GHORG_GITHUB_REPO_LIST_CONCURRENCY")
+		os.Unsetenv("GHORG_CLONE_PROTOCOL")
+		os.Unsetenv("GHORG_GITHUB_TOKEN")
+	}()
+
+	resp, err := gh.GetOrgRepos("conctest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp) != 4 {
+		t.Fatalf("want 4 repos, got %d", len(resp))
+	}
+	if maxInFlight > 2 {
+		t.Fatalf("max concurrent list requests was %d, want at most 2", maxInFlight)
+	}
+	if maxInFlight < 2 {
+		t.Fatalf("max concurrent list requests was %d, want 2 to confirm bounded parallelism", maxInFlight)
 	}
 }


### PR DESCRIPTION
Introduce GHORG_GITHUB_REPO_LIST_CONCURRENCY (and --github-repo-list-concurrency flag) to bound concurrent REST requests when listing GitHub org/user repos (pagination). Default behavior (env unset) remains: all pages fetched in parallel for speed. New scm/github_list.go implements worker-count logic, capped maximum (1024), rate-limit/error detection, exponential/backoff retry with capped waits and user-facing logging. fetchOrgReposParallel and fetchUserReposParallel updated to use bounded concurrency and the retry helper. CLI, sample-conf.yaml and PrintConfigs updated, and unit tests added for worker count and concurrency behavior.