### PR TITLE
Honor CLI overrides of config-enabled bool flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - `--protect-local --dry-run` now previews which existing local repos would be skipped due to uncommitted changes or unpushed commits (previously the dry-run output made no mention of protected repos, despite the documented behavior); thanks @mogsdad
 - `--dry-run` no longer double-spaces the repo URL list (each URL was ending with `\n\n` because `colorlog.PrintSubtleInfo` already appends a newline)
 - GitHub Actions use Go 1.26.0 so `go test` matches `go 1.26` and vendored module requirements (was 1.25.0 with `GOTOOLCHAIN=local`)
+- CLI bool flag overrides (e.g. `--no-clean=false`) are now honored against config-enabled flags; previously the override was silently dropped because the flag-to-env sync hardcoded `"true"` regardless of the parsed value, violating the documented "CLI > config > default" precedence.
 ### Security
 - Updated to go-term-markdown fork with updated depedencies
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -56,6 +56,17 @@ func shouldAutoAdjustConcurrency() (int, bool, bool) {
 	return delaySeconds, true, true
 }
 
+// syncBoolFlagToEnv mirrors a CLI bool flag onto its corresponding ghorg env
+// var. It preserves the documented "CLI > config > default" precedence,
+// including explicit --flag=false overrides of a config-enabled flag.
+func syncBoolFlagToEnv(cmd *cobra.Command, flagName, envVar string) {
+	if !cmd.Flags().Changed(flagName) {
+		return
+	}
+	v, _ := cmd.Flags().GetBool(flagName)
+	os.Setenv(envVar, strconv.FormatBool(v))
+}
+
 var cloneCmd = &cobra.Command{
 	Use:   "clone [org/user]",
 	Short: "Clone user or org repos from GitHub, GitLab, Gitea or Bitbucket",
@@ -255,109 +266,32 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_GIT_FILTER", filter)
 	}
 
-	if cmd.Flags().Changed("preserve-scm-hostname") {
-		os.Setenv("GHORG_PRESERVE_SCM_HOSTNAME", "true")
-	}
-
-	if cmd.Flags().Changed("skip-archived") {
-		os.Setenv("GHORG_SKIP_ARCHIVED", "true")
-	}
-
-	if cmd.Flags().Changed("stats-enabled") {
-		os.Setenv("GHORG_STATS_ENABLED", "true")
-	}
-
-	if cmd.Flags().Changed("no-clean") {
-		os.Setenv("GHORG_NO_CLEAN", "true")
-	}
-
-	if cmd.Flags().Changed("prune") {
-		os.Setenv("GHORG_PRUNE", "true")
-	}
-
-	if cmd.Flags().Changed("prune-no-confirm") {
-		os.Setenv("GHORG_PRUNE_NO_CONFIRM", "true")
-	}
-
-	if cmd.Flags().Changed("prune-untouched") {
-		os.Setenv("GHORG_PRUNE_UNTOUCHED", "true")
-	}
-
-	if cmd.Flags().Changed("prune-untouched-no-confirm") {
-		os.Setenv("GHORG_PRUNE_UNTOUCHED_NO_CONFIRM", "true")
-	}
-
-	if cmd.Flags().Changed("fetch-all") {
-		os.Setenv("GHORG_FETCH_ALL", "true")
-	}
-
-	if cmd.Flags().Changed("fetch-prune") {
-		os.Setenv("GHORG_FETCH_PRUNE", "true")
-	}
-
-	if cmd.Flags().Changed("include-submodules") {
-		os.Setenv("GHORG_INCLUDE_SUBMODULES", "true")
-	}
-
-	if cmd.Flags().Changed("dry-run") {
-		os.Setenv("GHORG_DRY_RUN", "true")
-	}
-
-	if cmd.Flags().Changed("clone-wiki") {
-		os.Setenv("GHORG_CLONE_WIKI", "true")
-	}
-
-	if cmd.Flags().Changed("clone-snippets") {
-		os.Setenv("GHORG_CLONE_SNIPPETS", "true")
-	}
-
-	if cmd.Flags().Changed("github-user-gists") {
-		os.Setenv("GHORG_GITHUB_USER_GISTS", "true")
-	}
-
-	if cmd.Flags().Changed("insecure-gitlab-client") {
-		os.Setenv("GHORG_INSECURE_GITLAB_CLIENT", "true")
-	}
-
-	if cmd.Flags().Changed("insecure-gitea-client") {
-		os.Setenv("GHORG_INSECURE_GITEA_CLIENT", "true")
-	}
-
-	if cmd.Flags().Changed("insecure-bitbucket-client") {
-		os.Setenv("GHORG_INSECURE_BITBUCKET_CLIENT", "true")
-	}
-
-	if cmd.Flags().Changed("insecure-sourcehut-client") {
-		os.Setenv("GHORG_INSECURE_SOURCEHUT_CLIENT", "true")
-	}
-
-	if cmd.Flags().Changed("skip-forks") {
-		os.Setenv("GHORG_SKIP_FORKS", "true")
-	}
-
-	if cmd.Flags().Changed("quiet") {
-		os.Setenv("GHORG_QUIET", "true")
-	}
-
-	if cmd.Flags().Changed("no-token") {
-		os.Setenv("GHORG_NO_TOKEN", "true")
-	}
-
-	if cmd.Flags().Changed("no-dir-size") {
-		os.Setenv("GHORG_NO_DIR_SIZE", "true")
-	}
-
-	if cmd.Flags().Changed("preserve-dir") {
-		os.Setenv("GHORG_PRESERVE_DIRECTORY_STRUCTURE", "true")
-	}
-
-	if cmd.Flags().Changed("backup") {
-		os.Setenv("GHORG_BACKUP", "true")
-	}
-
-	if cmd.Flags().Changed("protect-local") {
-		os.Setenv("GHORG_PROTECT_LOCAL", "true")
-	}
+	syncBoolFlagToEnv(cmd, "preserve-scm-hostname", "GHORG_PRESERVE_SCM_HOSTNAME")
+	syncBoolFlagToEnv(cmd, "skip-archived", "GHORG_SKIP_ARCHIVED")
+	syncBoolFlagToEnv(cmd, "stats-enabled", "GHORG_STATS_ENABLED")
+	syncBoolFlagToEnv(cmd, "no-clean", "GHORG_NO_CLEAN")
+	syncBoolFlagToEnv(cmd, "prune", "GHORG_PRUNE")
+	syncBoolFlagToEnv(cmd, "prune-no-confirm", "GHORG_PRUNE_NO_CONFIRM")
+	syncBoolFlagToEnv(cmd, "prune-untouched", "GHORG_PRUNE_UNTOUCHED")
+	syncBoolFlagToEnv(cmd, "prune-untouched-no-confirm", "GHORG_PRUNE_UNTOUCHED_NO_CONFIRM")
+	syncBoolFlagToEnv(cmd, "fetch-all", "GHORG_FETCH_ALL")
+	syncBoolFlagToEnv(cmd, "fetch-prune", "GHORG_FETCH_PRUNE")
+	syncBoolFlagToEnv(cmd, "include-submodules", "GHORG_INCLUDE_SUBMODULES")
+	syncBoolFlagToEnv(cmd, "dry-run", "GHORG_DRY_RUN")
+	syncBoolFlagToEnv(cmd, "clone-wiki", "GHORG_CLONE_WIKI")
+	syncBoolFlagToEnv(cmd, "clone-snippets", "GHORG_CLONE_SNIPPETS")
+	syncBoolFlagToEnv(cmd, "github-user-gists", "GHORG_GITHUB_USER_GISTS")
+	syncBoolFlagToEnv(cmd, "insecure-gitlab-client", "GHORG_INSECURE_GITLAB_CLIENT")
+	syncBoolFlagToEnv(cmd, "insecure-gitea-client", "GHORG_INSECURE_GITEA_CLIENT")
+	syncBoolFlagToEnv(cmd, "insecure-bitbucket-client", "GHORG_INSECURE_BITBUCKET_CLIENT")
+	syncBoolFlagToEnv(cmd, "insecure-sourcehut-client", "GHORG_INSECURE_SOURCEHUT_CLIENT")
+	syncBoolFlagToEnv(cmd, "skip-forks", "GHORG_SKIP_FORKS")
+	syncBoolFlagToEnv(cmd, "quiet", "GHORG_QUIET")
+	syncBoolFlagToEnv(cmd, "no-token", "GHORG_NO_TOKEN")
+	syncBoolFlagToEnv(cmd, "no-dir-size", "GHORG_NO_DIR_SIZE")
+	syncBoolFlagToEnv(cmd, "preserve-dir", "GHORG_PRESERVE_DIRECTORY_STRUCTURE")
+	syncBoolFlagToEnv(cmd, "backup", "GHORG_BACKUP")
+	syncBoolFlagToEnv(cmd, "protect-local", "GHORG_PROTECT_LOCAL")
 
 	if cmd.Flags().Changed("output-dir") {
 		d := cmd.Flag("output-dir").Value.String()

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gabrie30/ghorg/scm"
+	"github.com/spf13/cobra"
 )
 
 func TestShouldLowerRegularString(t *testing.T) {
@@ -1373,5 +1374,89 @@ func TestPreviewProtectLocal_EmptyRepoListReturnsZero(t *testing.T) {
 	}
 	if got := previewProtectLocal(mockGit, []scm.Repo{}); got != 0 {
 		t.Errorf("previewProtectLocal with empty slice returned %d, want 0", got)
+	}
+}
+
+// TestSyncBoolFlagToEnv covers the documented precedence "CLI > config > default"
+// for bool flags. The previous implementation hardcoded "true" whenever the user
+// passed the flag, which silently dropped explicit --flag=false overrides of a
+// config-enabled flag.
+func TestSyncBoolFlagToEnv(t *testing.T) {
+	const flagName = "no-clean"
+	const envVar = "GHORG_NO_CLEAN"
+
+	cases := []struct {
+		name      string
+		envBefore string // empty means env is unset
+		cliValue  string // empty means flag not passed
+		want      string // expected env value after sync; "<unset>" means env should be unset
+	}{
+		{
+			name:      "CLI=false overrides config=true",
+			envBefore: "true",
+			cliValue:  "false",
+			want:      "false",
+		},
+		{
+			name:      "CLI=true overrides config=false",
+			envBefore: "false",
+			cliValue:  "true",
+			want:      "true",
+		},
+		{
+			name:      "bare flag (no value) defaults to true and overrides config=false",
+			envBefore: "false",
+			cliValue:  "bare",
+			want:      "true",
+		},
+		{
+			name:      "flag not passed leaves config value intact",
+			envBefore: "true",
+			cliValue:  "",
+			want:      "true",
+		},
+		{
+			name:      "flag not passed and env unset leaves env unset",
+			envBefore: "",
+			cliValue:  "",
+			want:      "<unset>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer UnsetEnv("GHORG_")()
+			if tc.envBefore != "" {
+				os.Setenv(envVar, tc.envBefore)
+			}
+
+			cmd := &cobra.Command{Use: "clone"}
+			cmd.Flags().Bool(flagName, false, "")
+
+			if tc.cliValue != "" {
+				var err error
+				if tc.cliValue == "bare" {
+					err = cmd.ParseFlags([]string{"--" + flagName})
+				} else {
+					err = cmd.ParseFlags([]string{"--" + flagName + "=" + tc.cliValue})
+				}
+				if err != nil {
+					t.Fatalf("ParseFlags failed: %v", err)
+				}
+			}
+
+			syncBoolFlagToEnv(cmd, flagName, envVar)
+
+			got, present := os.LookupEnv(envVar)
+			if tc.want == "<unset>" {
+				if present {
+					t.Fatalf("want %s unset, got %q", envVar, got)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("want %s=%q, got %q", envVar, tc.want, got)
+			}
+		})
 	}
 }

--- a/cmd/reclone.go
+++ b/cmd/reclone.go
@@ -36,13 +36,8 @@ func reCloneFunc(cmd *cobra.Command, argz []string) {
 		os.Setenv("GHORG_RECLONE_PATH", path)
 	}
 
-	if cmd.Flags().Changed("quiet") {
-		os.Setenv("GHORG_RECLONE_QUIET", "true")
-	}
-
-	if cmd.Flags().Changed("env-config-only") {
-		os.Setenv("GHORG_RECLONE_ENV_CONFIG_ONLY", "true")
-	}
+	syncBoolFlagToEnv(cmd, "quiet", "GHORG_RECLONE_QUIET")
+	syncBoolFlagToEnv(cmd, "env-config-only", "GHORG_RECLONE_ENV_CONFIG_ONLY")
 
 	path := configs.GhorgReCloneLocation()
 	yamlBytes, err := os.ReadFile(path)


### PR DESCRIPTION
Fixes #647 

## Status
**READY**

## Description

Goal: restore the precedence promised by `ghorg clone --help` ("Values are set first by a default value, then based off what is set in $HOME/.config/ghorg/conf.yaml, finally the cli flags, which have the highest level of precedence") for every bool flag in `clone` and `reclone`.

1. **`cmd/clone.go`** — introduce `syncBoolFlagToEnv(cmd, flagName, envVar)` helper next to the existing `parseIntEnv` / `getCloneDelaySeconds` utility helpers. Replace the 26 repeated `if Changed(...) { Setenv(..., "true") }` blocks (lines 258–359 on master) with one-line calls. Net `cmd/clone.go`: −103 / +37.
2. **`cmd/reclone.go`** — same fix for the two bool flags that had the identical anti-pattern (`--quiet`, `--env-config-only`). Net: −6 / +2.
3. **`cmd/clone_test.go`** — add `TestSyncBoolFlagToEnv`, a five-case table-driven test covering:
    - CLI `=false` over env `=true` (the bug)
    - CLI `=true` over env `=false`
    - Bare `--flag` over env `=false` (verifies cobra's `NoOptDefVal` still wins)
    - Flag not passed → env unchanged
    - Flag not passed and env unset → env still unset

`CHANGELOG.md` gets a one-line entry under `[1.11.11] - unreleased` / `### Fixed`.

### Behavior change scope

Strictly limited to the previously-broken case (CLI `=false` while config sets env to `true`). Bare `--flag` and `--flag=true` still set env to `true` via cobra's `NoOptDefVal`. Anyone whose workflow relied on the bug (passing `--flag=false` expecting it to be ignored) would be doing something contradictory.

### Verified

- `go test ./...` green
- End-to-end repro from the issue now shows `No Clean: false` / `Prune: false` (or omits those lines since they only print when `true`) under the patched binary
- Symmetric check: CLI `=true` over config `=false` also works
- Spot-checked a third flag (`--dry-run=true`) to confirm coverage isn't accidentally `no-clean`-specific

## AI Assistance

Yes — Claude Opus 4.7 (Anthropic, via Claude Code CLI) helped with:

- Codebase exploration (locating the anti-pattern across `cmd/`, confirming the bug was the same across all 28 affected flags)
- Drafting the helper signature and the table-driven test cases
- Drafting this PR body, the issue body, and the CHANGELOG entry

All changes were reviewed and edited by me before commit. Tests were written and run locally, verification was executed in my environment.
