### PR TITLE
feat(clone): add --fetch-git-lfs flag

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -275,6 +275,7 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 	syncBoolFlagToEnv(cmd, "prune-untouched", "GHORG_PRUNE_UNTOUCHED")
 	syncBoolFlagToEnv(cmd, "prune-untouched-no-confirm", "GHORG_PRUNE_UNTOUCHED_NO_CONFIRM")
 	syncBoolFlagToEnv(cmd, "fetch-all", "GHORG_FETCH_ALL")
+	syncBoolFlagToEnv(cmd, "fetch-git-lfs", "GHORG_FETCH_GIT_LFS")
 	syncBoolFlagToEnv(cmd, "fetch-prune", "GHORG_FETCH_PRUNE")
 	syncBoolFlagToEnv(cmd, "include-submodules", "GHORG_INCLUDE_SUBMODULES")
 	syncBoolFlagToEnv(cmd, "dry-run", "GHORG_DRY_RUN")
@@ -1432,6 +1433,9 @@ func PrintConfigs() {
 	}
 	if os.Getenv("GHORG_FETCH_ALL") == "true" {
 		colorlog.PrintInfo("* Fetch All     : " + "true")
+	}
+	if os.Getenv("GHORG_FETCH_GIT_LFS") == "true" {
+		colorlog.PrintInfo("* Fetch Git LFS : " + "true")
 	}
 	if os.Getenv("GHORG_FETCH_PRUNE") == "true" {
 		colorlog.PrintInfo("* Fetch Prune   : " + "true")

--- a/cmd/clone_test.go
+++ b/cmd/clone_test.go
@@ -201,6 +201,10 @@ func (g MockGitClient) ShortStatus(repo scm.Repo) (string, error) {
 	return "", nil
 }
 
+func (g MockGitClient) LfsFetchAll(repo scm.Repo) error {
+	return nil
+}
+
 func TestInitialClone(t *testing.T) {
 	defer UnsetEnv("GHORG_")()
 	dir, err := os.MkdirTemp("", "ghorg_test_initial")

--- a/cmd/repository_processor.go
+++ b/cmd/repository_processor.go
@@ -301,6 +301,14 @@ func (rp *RepositoryProcessor) handleExistingRepository(repo *scm.Repo, action *
 		success = rp.handleStandardPull(repo)
 	}
 
+	if success && os.Getenv("GHORG_FETCH_GIT_LFS") == "true" {
+		err = rp.git.LfsFetchAll(*repo)
+		if err != nil {
+			rp.addError(fmt.Sprintf("Problem trying to fetch Git LFS: %s Error: %v", repo.URL, err))
+			success = false
+		}
+	}
+
 	// Always reset origin to remove credentials, even if processing failed
 	err = rp.git.SetOrigin(*repo)
 	if err != nil {
@@ -387,6 +395,14 @@ func (rp *RepositoryProcessor) handleNewRepository(repo *scm.Repo, action *strin
 		// Report fetch error if it occurred
 		if fetchErr != nil {
 			rp.addError(fmt.Sprintf("Could not fetch remotes: %s Error: %v", repo.URL, fetchErr))
+			return false
+		}
+	}
+
+	if os.Getenv("GHORG_FETCH_GIT_LFS") == "true" {
+		err = rp.git.LfsFetchAll(*repo)
+		if err != nil {
+			rp.addError(fmt.Sprintf("Problem trying to fetch Git LFS: %s Error: %v", repo.URL, err))
 			return false
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ var (
 	insecureBitbucketClient      bool
 	insecureSourcehutClient      bool
 	fetchAll                     bool
+	fetchGitLfs                  bool
 	fetchPrune                   bool
 	ghorgReCloneQuiet            bool
 	ghorgReCloneList             bool
@@ -401,6 +402,7 @@ func init() {
 	cloneCmd.Flags().BoolVar(&prune, "prune", false, "GHORG_PRUNE - Remove local repositories that no longer exist remotely. When used with --skip-archived, also removes archived repos locally. Prompts before deletion unless combined with --prune-no-confirm")
 	cloneCmd.Flags().BoolVar(&pruneNoConfirm, "prune-no-confirm", false, "GHORG_PRUNE_NO_CONFIRM - Skip confirmation prompts when pruning repositories. Use with caution as this will delete directories without asking")
 	cloneCmd.Flags().BoolVar(&fetchAll, "fetch-all", false, "GHORG_FETCH_ALL - Fetch all remote branches for each repository using 'git fetch --all'. Useful for getting complete branch information")
+	cloneCmd.Flags().BoolVar(&fetchGitLfs, "fetch-git-lfs", false, "GHORG_FETCH_GIT_LFS - Fetch git LFS (large file storage) content for each repository using 'git lfs fetch --all'. Useful for backing up repositories that use Git LFS.")
 	cloneCmd.Flags().BoolVar(&fetchPrune, "fetch-prune", false, "GHORG_FETCH_PRUNE - Remove stale remote-tracking branches during fetch (adds --prune to git fetch). Only applies when --fetch-all is used. Note: This is different from --prune which removes local clone directories")
 	cloneCmd.Flags().BoolVar(&dryRun, "dry-run", false, "GHORG_DRY_RUN - Simulate the clone operation without actually cloning repositories. Shows what would be cloned for testing/verification")
 	cloneCmd.Flags().BoolVar(&insecureGitlabClient, "insecure-gitlab-client", false, "GHORG_INSECURE_GITLAB_CLIENT - Skip TLS certificate verification for self-hosted GitLab instances. Use only for internal/trusted instances")

--- a/git/git.go
+++ b/git/git.go
@@ -31,6 +31,7 @@ type Gitter interface {
 	FetchCloneBranch(scm.Repo) error
 	RepoCommitCount(scm.Repo) (int, error)
 	HasRemoteHeads(scm.Repo) (bool, error)
+	LfsFetchAll(scm.Repo) error
 }
 
 type GitClient struct{}
@@ -360,4 +361,19 @@ func (g GitClient) RepoCommitCount(repo scm.Repo) (int, error) {
 	}
 
 	return count, nil
+}
+
+func (g GitClient) LfsFetchAll(repo scm.Repo) error {
+	args := []string{"lfs", "fetch", "--all"}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo.HostPath
+
+	if os.Getenv("GHORG_DEBUG") != "" {
+		err := printDebugCmd(cmd, repo)
+		if err != nil {
+			return err
+		}
+	}
+
+	return cmd.Run()
 }


### PR DESCRIPTION
## Status
**READY**

## Description
A few sentences describing the overall goals of the pull request's commits.

This PR adds support for Git LFS in the `clone` command. When users pass `--fetch-git-lfs`, `ghorg` will run `git lfs fetch --all` on every repo which will correctly fetch all LFS objects from the upstream repository.

This adds the feature that I need from this discussion thread: https://github.com/gabrie30/ghorg/discussions/466

## AI Assistance
Were any AI/LLM tools used to help author this Pull Request? If so, which model(s)?

No
