### PR TITLE
Add GHORG_GITLAB_INCLUDE_SHARED_PROJECTS flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## [1.11.12] - unreleased
 ### Added
 - GHORG_FETCH_GIT_LFS to run git lfs fetch --all on every repo which will correctly fetch all LFS objects from the upstream repository; thanks @dotboris
+- GHORG_GITLAB_INCLUDE_SHARED_PROJECTS (--gitlab-include-shared-projects), GitLab only, defaults to true; set to false to skip projects that are only shared with a group rather than owned by it
 ### Changed
 - `ghorg reclone --list` now returns a sorted list
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- GitLab `all-groups` clones no longer clone a project twice when it is shared across multiple groups (previously the duplicate caused a clone/pull race when preserving the directory structure); projects are now deduplicated by clone URL
 ### Security
 
 ## [1.11.11] - 5/12/26

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ brew install ghorg
 
 ### Mise
 
-If you are an enthusiast user of [Mise](https://github.com/jdx/mise), the polyglot tool versions manager, you can use such command to install the latest version of `ghorg` on Linux/MacOS/Windows:
+If you use [Mise](https://github.com/jdx/mise), you can install the latest version of `ghorg` on Linux/MacOS/Windows:
 
 ```bash
 mise use -g ghorg@latest

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -283,6 +283,7 @@ func cloneFunc(cmd *cobra.Command, argz []string) {
 	syncBoolFlagToEnv(cmd, "clone-snippets", "GHORG_CLONE_SNIPPETS")
 	syncBoolFlagToEnv(cmd, "github-user-gists", "GHORG_GITHUB_USER_GISTS")
 	syncBoolFlagToEnv(cmd, "insecure-gitlab-client", "GHORG_INSECURE_GITLAB_CLIENT")
+	syncBoolFlagToEnv(cmd, "gitlab-include-shared-projects", "GHORG_GITLAB_INCLUDE_SHARED_PROJECTS")
 	syncBoolFlagToEnv(cmd, "insecure-gitea-client", "GHORG_INSECURE_GITEA_CLIENT")
 	syncBoolFlagToEnv(cmd, "insecure-bitbucket-client", "GHORG_INSECURE_BITBUCKET_CLIENT")
 	syncBoolFlagToEnv(cmd, "insecure-sourcehut-client", "GHORG_INSECURE_SOURCEHUT_CLIENT")
@@ -1408,6 +1409,9 @@ func PrintConfigs() {
 	}
 	if os.Getenv("GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX") != "" {
 		colorlog.PrintInfo("* GL Grp Exclude: " + os.Getenv("GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX"))
+	}
+	if os.Getenv("GHORG_GITLAB_INCLUDE_SHARED_PROJECTS") == "false" {
+		colorlog.PrintInfo("* GL Shared Proj: skipped")
 	}
 	if os.Getenv("GHORG_INCLUDE_SUBMODULES") == "true" {
 		colorlog.PrintInfo("* Submodules    : " + os.Getenv("GHORG_INCLUDE_SUBMODULES"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ var (
 	cloneSnippets                bool
 	preserveDir                  bool
 	insecureGitlabClient         bool
+	gitlabIncludeSharedProjects  bool
 	insecureGiteaClient          bool
 	insecureBitbucketClient      bool
 	insecureSourcehutClient      bool
@@ -199,6 +200,8 @@ func getOrSetDefaults(envVar string) {
 			os.Setenv(envVar, "false")
 		case "GHORG_INSECURE_GITLAB_CLIENT":
 			os.Setenv(envVar, "false")
+		case "GHORG_GITLAB_INCLUDE_SHARED_PROJECTS":
+			os.Setenv(envVar, "true")
 		case "GHORG_INSECURE_GITEA_CLIENT":
 			os.Setenv(envVar, "false")
 		case "GHORG_INSECURE_BITBUCKET_CLIENT":
@@ -357,6 +360,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_EXCLUDE_MATCH_PREFIX")
 	getOrSetDefaults("GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX")
 	getOrSetDefaults("GHORG_GITLAB_GROUP_MATCH_REGEX")
+	getOrSetDefaults("GHORG_GITLAB_INCLUDE_SHARED_PROJECTS")
 	getOrSetDefaults("GHORG_IGNORE_PATH")
 	getOrSetDefaults("GHORG_RECLONE_PATH")
 	getOrSetDefaults("GHORG_QUIET")
@@ -435,6 +439,7 @@ func init() {
 	cloneCmd.Flags().StringVarP(&excludeMatchRegex, "exclude-match-regex", "", "", "GHORG_EXCLUDE_MATCH_REGEX - Exclude repositories whose names match the provided regular expression")
 	cloneCmd.Flags().StringVarP(&gitlabGroupExcludeMatchRegex, "gitlab-group-exclude-match-regex", "", "", "GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX - GitLab only: Exclude groups/subgroups matching the regex pattern")
 	cloneCmd.Flags().StringVarP(&gitlabGroupMatchRegex, "gitlab-group-match-regex", "", "", "GHORG_GITLAB_GROUP_MATCH_REGEX - GitLab only: Only clone from groups/subgroups matching the regex pattern")
+	cloneCmd.Flags().BoolVar(&gitlabIncludeSharedProjects, "gitlab-include-shared-projects", true, "GHORG_GITLAB_INCLUDE_SHARED_PROJECTS - GitLab only: Include projects shared with the group, not just those owned by it. Set to false to skip shared projects (default: true)")
 	cloneCmd.Flags().StringVarP(&ghorgIgnorePath, "ghorgignore-path", "", "", "GHORG_IGNORE_PATH - Custom path to ghorgignore file (similar to .gitignore but for repos). Default: $HOME/.config/ghorg/ghorgignore")
 	cloneCmd.Flags().StringVarP(&ghorgOnlyPath, "ghorgonly-path", "", "", "GHORG_ONLY_PATH - Custom path to ghorgonly file (whitelist of repos to clone). Default: $HOME/.config/ghorg/ghorgonly")
 	cloneCmd.Flags().StringVarP(&exitCodeOnCloneInfos, "exit-code-on-clone-infos", "", "", "GHORG_EXIT_CODE_ON_CLONE_INFOS - Exit code when informational messages occur during cloning (non-critical issues). Useful for CI/CD pipelines (default: 0)")

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -339,6 +339,11 @@ GHORG_GITLAB_GROUP_MATCH_REGEX:
 # flag (--gitlab-group-exclude-match-regex)
 GHORG_GITLAB_GROUP_EXCLUDE_MATCH_REGEX:
 
+# Include projects shared with the group, not just those owned by it
+# set to false to skip projects that are only shared with the group
+# flag (--gitlab-include-shared-projects)
+GHORG_GITLAB_INCLUDE_SHARED_PROJECTS: true
+
 # Additionally clone all snippets
 # flag (--clone-snippets)
 GHORG_CLONE_SNIPPETS: false

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -111,6 +111,12 @@ func (c Gitlab) GetOrgRepos(targetOrg string) ([]Repo, error) {
 
 	}
 
+	// A project shared with another group is returned both by the group that owns
+	// it and by every group it is shared with. In all-groups mode that means the
+	// same project is collected multiple times, which would clone it twice to the
+	// same destination. Dedupe by clone URL so each project is only cloned once.
+	repoData = dedupeReposByCloneURL(repoData)
+
 	snippets, err := c.GetSnippets(repoData, targetOrg)
 	if err != nil {
 		spinningSpinner.Stop()
@@ -119,6 +125,22 @@ func (c Gitlab) GetOrgRepos(targetOrg string) ([]Repo, error) {
 	repoData = append(repoData, snippets...)
 
 	return repoData, nil
+}
+
+// dedupeReposByCloneURL returns repos with duplicate clone URLs removed,
+// preserving the order of first occurrence. This guards against cloning the
+// same project more than once when it is shared across multiple groups.
+func dedupeReposByCloneURL(repos []Repo) []Repo {
+	seen := make(map[string]struct{}, len(repos))
+	deduped := make([]Repo, 0, len(repos))
+	for _, r := range repos {
+		if _, ok := seen[r.CloneURL]; ok {
+			continue
+		}
+		seen[r.CloneURL] = struct{}{}
+		deduped = append(deduped, r)
+	}
+	return deduped
 }
 
 // GetTopLevelGroups all top level org groups with parallel pagination

--- a/scm/gitlab.go
+++ b/scm/gitlab.go
@@ -361,6 +361,7 @@ func (c Gitlab) GetGroupRepos(targetGroup string) ([]Repo, error) {
 			Page:    1,
 		},
 		IncludeSubGroups: gitlab.Ptr(true),
+		WithShared:       gitlab.Ptr(os.Getenv("GHORG_GITLAB_INCLUDE_SHARED_PROJECTS") != "false"),
 	}
 
 	// Fetch first page to discover total number of pages

--- a/scm/gitlab_parallel.go
+++ b/scm/gitlab_parallel.go
@@ -3,6 +3,7 @@ package scm
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 
@@ -107,6 +108,7 @@ func (c Gitlab) fetchGroupReposParallel(targetGroup string, firstPageProjects []
 				Page:    int64(pageNum),
 			},
 			IncludeSubGroups: gitlab.Ptr(true),
+			WithShared:       gitlab.Ptr(os.Getenv("GHORG_GITLAB_INCLUDE_SHARED_PROJECTS") != "false"),
 		}
 
 			ps, _, err := c.Groups.ListGroupProjects(targetGroup, opt)

--- a/scripts/local-gitlab/README.md
+++ b/scripts/local-gitlab/README.md
@@ -248,9 +248,19 @@ Defines the GitLab resources to create during seeding:
   ],
   "users": [...],
   "root_user": {...},
-  "root_snippets": [...]
+  "root_snippets": [...],
+  "shared_projects": [
+    {
+      "project_path": "owner-group/owned-repo",
+      "shared_with_group_path": "target-group"
+    }
+  ]
 }
 ```
+
+`shared_projects` shares an existing project (created under `groups`) with another
+group after all groups are created. This mirrors GitLab's "share a project with a
+group" feature and is used to exercise the `--gitlab-include-shared-projects` flag.
 
 ### Test Scenarios Configuration (`configs/test-scenarios.json`)
 
@@ -269,11 +279,18 @@ Defines the integration test scenarios:
       "expected_structure": [
         "test-output/group1/repo1",
         "test-output/group2/repo2"
+      ],
+      "unexpected_structure": [
+        "test-output/group1/repo-that-should-not-be-cloned"
       ]
     }
   ]
 }
 ```
+
+`unexpected_structure` is optional and lists paths that must **not** exist after the
+command runs (e.g. a shared project that was skipped via
+`--gitlab-include-shared-projects=false`).
 
 ## Adding New Seed Data
 

--- a/scripts/local-gitlab/configs/seed-data.json
+++ b/scripts/local-gitlab/configs/seed-data.json
@@ -196,6 +196,34 @@
                     ]
                 }
             ]
+        },
+        {
+            "name": "local-gitlab-shared-owner-group",
+            "path": "local-gitlab-shared-owner-group",
+            "description": "Owns a project that is shared into another group (shared projects test)",
+            "repositories": [
+                {
+                    "name": "shared-owner-repo",
+                    "initialize_with_readme": true
+                }
+            ]
+        },
+        {
+            "name": "local-gitlab-shared-target-group",
+            "path": "local-gitlab-shared-target-group",
+            "description": "Target group that has a project shared with it (shared projects test)",
+            "repositories": [
+                {
+                    "name": "target-owned-repo",
+                    "initialize_with_readme": true
+                }
+            ]
+        }
+    ],
+    "shared_projects": [
+        {
+            "project_path": "local-gitlab-shared-owner-group/shared-owner-repo",
+            "shared_with_group_path": "local-gitlab-shared-target-group"
         }
     ],
     "users": [

--- a/scripts/local-gitlab/configs/test-scenarios.json
+++ b/scripts/local-gitlab/configs/test-scenarios.json
@@ -719,6 +719,28 @@
             ]
         },
         {
+            "name": "gitlab-include-shared-projects-default",
+            "description": "Test that projects shared with a group are cloned by default (with_shared)",
+            "command": "ghorg clone local-gitlab-shared-target-group --scm=gitlab --base-url={{.BaseURL}} --token={{.Token}} --output-dir=gitlab-shared-projects-default-test",
+            "run_twice": false,
+            "expected_structure": [
+                "gitlab-shared-projects-default-test/target-owned-repo",
+                "gitlab-shared-projects-default-test/shared-owner-repo"
+            ]
+        },
+        {
+            "name": "gitlab-skip-shared-projects",
+            "description": "Test that --gitlab-include-shared-projects=false skips projects only shared with the group",
+            "command": "ghorg clone local-gitlab-shared-target-group --scm=gitlab --base-url={{.BaseURL}} --token={{.Token}} --gitlab-include-shared-projects=false --output-dir=gitlab-skip-shared-projects-test",
+            "run_twice": false,
+            "expected_structure": [
+                "gitlab-skip-shared-projects-test/target-owned-repo"
+            ],
+            "unexpected_structure": [
+                "gitlab-skip-shared-projects-test/shared-owner-repo"
+            ]
+        },
+        {
             "_comment": "COMMENTED OUT TEST FROM ORIGINAL SCRIPT - TODO FIXME",
             "name": "root-level-snippets-test-disabled",
             "description": "Test root level snippets (DISABLED - was commented in original)",

--- a/scripts/local-gitlab/get_credentials.sh
+++ b/scripts/local-gitlab/get_credentials.sh
@@ -8,23 +8,48 @@ GITLAB_URL=$1
 LOCAL_GITLAB_GHORG_DIR=$2
 started="0"
 counter=0
+# ~30 minutes at 10s per attempt; override with GITLAB_READY_MAX_ATTEMPTS if needed
+max_attempts=${GITLAB_READY_MAX_ATTEMPTS:-180}
 
-until [ $started -eq "1" ]
+dump_diagnostics() {
+  echo "=== Diagnostics: GitLab did not become ready ==="
+  echo "--- docker ps -a ---"
+  docker ps -a || true
+  echo "--- last response headers from ${GITLAB_URL}/user/sign_in ---"
+  curl -I -sS -L "${GITLAB_URL}/user/sign_in" || true
+  echo "--- docker logs gitlab (last 200 lines) ---"
+  docker logs --tail 200 gitlab || true
+}
+
+until [ "$started" -eq "1" ]
 do
-  resp=$(curl -I -s -L "${GITLAB_URL}"/user/sign_in | grep "HTTP/1.1 200 OK" | cut -d$' ' -f2)
-
-  if [ $counter -gt 100 ]; then
+  if [ "$counter" -gt "$max_attempts" ]; then
     echo "GitLab isn't starting properly, exiting"
+    dump_diagnostics
     exit 1
   fi
+
+  # Use the returned HTTP status code directly so the readiness check is agnostic
+  # to the HTTP version in the status line (HTTP/1.1 vs HTTP/2) and to header
+  # formatting differences across curl versions.
+  resp=$(curl -s -o /dev/null -L -w "%{http_code}" "${GITLAB_URL}/user/sign_in" || true)
 
   if [ "${resp}" = "200" ]; then
     started="1"
     echo "GitLab is fully up and running..."
+    break
   fi
+
+  # Periodically surface the current status code and recent container logs so a
+  # hung or crashing boot is visible in CI output instead of a silent wait.
+  if [ $((counter % 12)) -eq 0 ]; then
+    echo "Latest HTTP status from ${GITLAB_URL}/user/sign_in: '${resp:-no response}'"
+    docker logs --tail 5 gitlab 2>&1 || true
+  fi
+
   sleep 10
-  ((counter++))
-  echo "GitLab has not started, sleeping...count: ${counter}"
+  ((counter++)) || true
+  echo "GitLab has not started, sleeping...count: ${counter} (status: ${resp:-none})"
 done
 
 set -x

--- a/scripts/local-gitlab/seeder/main.go
+++ b/scripts/local-gitlab/seeder/main.go
@@ -44,11 +44,17 @@ type RootUser struct {
 	Repositories []Repository `json:"repositories"`
 }
 
+type SharedProject struct {
+	ProjectPath         string `json:"project_path"`
+	SharedWithGroupPath string `json:"shared_with_group_path"`
+}
+
 type SeedData struct {
-	Groups       []Group   `json:"groups"`
-	Users        []User    `json:"users"`
-	RootUser     RootUser  `json:"root_user"`
-	RootSnippets []Snippet `json:"root_snippets"`
+	Groups         []Group         `json:"groups"`
+	Users          []User          `json:"users"`
+	RootUser       RootUser        `json:"root_user"`
+	RootSnippets   []Snippet       `json:"root_snippets"`
+	SharedProjects []SharedProject `json:"shared_projects"`
 }
 
 type GitLabSeeder struct {
@@ -328,10 +334,52 @@ func (g *GitLabSeeder) createRootSnippet(snippet *Snippet) error {
 	return nil
 }
 
+func (g *GitLabSeeder) ShareProjects() error {
+	if len(g.seedData.SharedProjects) == 0 {
+		return nil
+	}
+
+	log.Println("Sharing projects with groups...")
+
+	for _, shared := range g.seedData.SharedProjects {
+		if err := g.shareProject(&shared); err != nil {
+			return fmt.Errorf("failed to share project %s with group %s: %w", shared.ProjectPath, shared.SharedWithGroupPath, err)
+		}
+	}
+	return nil
+}
+
+func (g *GitLabSeeder) shareProject(shared *SharedProject) error {
+	log.Printf("Sharing project %s with group %s", shared.ProjectPath, shared.SharedWithGroupPath)
+
+	// Resolve the target group by its full path to get its ID
+	group, _, err := g.client.Groups.GetGroup(shared.SharedWithGroupPath, &gitlab.GetGroupOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get group: %w", err)
+	}
+
+	shareOptions := &gitlab.ShareWithGroupOptions{
+		GroupID:     &group.ID,
+		GroupAccess: gitlab.Ptr(gitlab.DeveloperPermissions),
+	}
+
+	// The project is identified by its full path (namespace/project)
+	if _, err := g.client.Projects.ShareProjectWithGroup(shared.ProjectPath, shareOptions); err != nil {
+		return fmt.Errorf("failed to share project: %w", err)
+	}
+
+	log.Printf("Shared project %s with group %s", shared.ProjectPath, shared.SharedWithGroupPath)
+	return nil
+}
+
 func (g *GitLabSeeder) SeedAll() error {
 	log.Println("Starting GitLab seeding process...")
 
 	if err := g.CreateGroups(); err != nil {
+		return err
+	}
+
+	if err := g.ShareProjects(); err != nil {
 		return err
 	}
 

--- a/scripts/local-gitlab/test-runner/main.go
+++ b/scripts/local-gitlab/test-runner/main.go
@@ -20,6 +20,7 @@ type TestScenario struct {
 	SetupCommands         []string `json:"setup_commands,omitempty"`
 	VerifyCommands        []string `json:"verify_commands,omitempty"`
 	ExpectedStructure     []string `json:"expected_structure"`
+	UnexpectedStructure   []string `json:"unexpected_structure,omitempty"`
 	Disabled              bool     `json:"disabled,omitempty"`
 	SkipTokenVerification bool     `json:"skip_token_verification,omitempty"`
 }
@@ -145,6 +146,11 @@ func (tr *TestRunner) runTest(scenario *TestScenario) error {
 		return fmt.Errorf("structure verification failed: %w", err)
 	}
 
+	// Verify paths that must NOT exist (e.g. shared projects that were skipped)
+	if err := tr.verifyUnexpectedStructure(scenario.UnexpectedStructure); err != nil {
+		return fmt.Errorf("unexpected structure verification failed: %w", err)
+	}
+
 	// Verify no tokens in git remotes by default (unless explicitly skipped)
 	if len(scenario.ExpectedStructure) > 0 && !scenario.SkipTokenVerification {
 		if err := tr.verifyNoTokensInRemotes(scenario.ExpectedStructure, tr.context.Token); err != nil {
@@ -218,6 +224,28 @@ func (tr *TestRunner) verifyExpectedStructure(expectedPaths []string) error {
 		}
 
 		log.Printf("✓ Found: %s", expectedPath)
+	}
+
+	return nil
+}
+
+func (tr *TestRunner) verifyUnexpectedStructure(unexpectedPaths []string) error {
+	if len(unexpectedPaths) == 0 {
+		return nil
+	}
+
+	log.Printf("Verifying unexpected structure (%d paths should not exist)...", len(unexpectedPaths))
+
+	for _, unexpectedPath := range unexpectedPaths {
+		fullPath := filepath.Join(tr.context.GhorgDir, unexpectedPath)
+
+		if _, err := os.Stat(fullPath); err == nil {
+			return fmt.Errorf("path exists but should not: %s", unexpectedPath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to check path %s: %w", unexpectedPath, err)
+		}
+
+		log.Printf("✓ Absent (as expected): %s", unexpectedPath)
 	}
 
 	return nil


### PR DESCRIPTION
Adds a new GitLab-specific flag `--gitlab-include-shared-projects` (env: `GHORG_GITLAB_INCLUDE_SHARED_PROJECTS`) that controls whether projects shared with a group are included when cloning. Defaults to `true` (existing behavior). Set to `false` to skip projects that are only shared with a group rather than owned by it.

Also adds integration test support: seed data creates shared project fixtures, test scenarios validate both default (include) and opt-out (exclude) behavior, and the test runner gains an `unexpected_structure` check to assert paths do not exist.

Fixes https://github.com/gabrie30/ghorg/issues/653