### PR TITLE
Add GHORG_TOKEN_CMD for external token sourcing

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -333,6 +333,7 @@ func InitConfig() {
 	getOrSetDefaults("GHORG_CRON_TIMER_MINUTES")
 	getOrSetDefaults("GHORG_RECLONE_SERVER_PORT")
 	// Optionally set
+	getOrSetDefaults("GHORG_TOKEN_CMD")
 	getOrSetDefaults("GHORG_TARGET_REPOS_PATH")
 	getOrSetDefaults("GHORG_CLONE_DEPTH")
 	getOrSetDefaults("GHORG_GITHUB_TOKEN")

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -232,8 +232,86 @@ func GetTokenFromFile(path string) string {
 	return cleaned.String()
 }
 
+// runTokenCmd executes GHORG_TOKEN_CMD, if set, and assigns its stdout to the
+// token env var for the active scm. This lets users source tokens from an
+// external secrets manager (e.g. mise, pass, a keyring CLI) instead of storing
+// them in cleartext in conf.yaml. An explicitly set token always takes
+// precedence, so the command is only run when no token is already present.
+func runTokenCmd() {
+	command := os.Getenv("GHORG_TOKEN_CMD")
+	if command == "" {
+		return
+	}
+
+	scmType := os.Getenv("GHORG_SCM_TYPE")
+
+	// Skip running the command when a token is already set for the active scm.
+	switch scmType {
+	case "github":
+		if !isZero(os.Getenv("GHORG_GITHUB_TOKEN")) {
+			return
+		}
+	case "gitlab":
+		if !isZero(os.Getenv("GHORG_GITLAB_TOKEN")) {
+			return
+		}
+	case "gitea":
+		if !isZero(os.Getenv("GHORG_GITEA_TOKEN")) {
+			return
+		}
+	case "sourcehut":
+		if !isZero(os.Getenv("GHORG_SOURCEHUT_TOKEN")) {
+			return
+		}
+	case "bitbucket":
+		if !isZero(os.Getenv("GHORG_BITBUCKET_APP_PASSWORD")) || !isZero(os.Getenv("GHORG_BITBUCKET_OAUTH_TOKEN")) || !isZero(os.Getenv("GHORG_BITBUCKET_API_TOKEN")) {
+			return
+		}
+	default:
+		return
+	}
+
+	var out []byte
+	var err error
+	if runtime.GOOS == "windows" {
+		out, err = exec.Command("cmd", "/C", command).Output()
+	} else {
+		out, err = exec.Command("sh", "-c", command).Output()
+	}
+	if err != nil {
+		log.Fatalf("Error running GHORG_TOKEN_CMD (%q): %v", command, err)
+	}
+
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		log.Fatalf("GHORG_TOKEN_CMD (%q) produced no output", command)
+	}
+
+	switch scmType {
+	case "github":
+		os.Setenv("GHORG_GITHUB_TOKEN", token)
+	case "gitlab":
+		os.Setenv("GHORG_GITLAB_TOKEN", token)
+	case "gitea":
+		os.Setenv("GHORG_GITEA_TOKEN", token)
+	case "sourcehut":
+		os.Setenv("GHORG_SOURCEHUT_TOKEN", token)
+	case "bitbucket":
+		// Mirror the keychain fallback's credential selection: app password when
+		// a username is set, API token when an API email is set, else oauth.
+		if !isZero(os.Getenv("GHORG_BITBUCKET_USERNAME")) {
+			os.Setenv("GHORG_BITBUCKET_APP_PASSWORD", token)
+		} else if !isZero(os.Getenv("GHORG_BITBUCKET_API_EMAIL")) {
+			os.Setenv("GHORG_BITBUCKET_API_TOKEN", token)
+		} else {
+			os.Setenv("GHORG_BITBUCKET_OAUTH_TOKEN", token)
+		}
+	}
+}
+
 // GetOrSetToken will set token based on scm
 func GetOrSetToken() {
+	runTokenCmd()
 	switch os.Getenv("GHORG_SCM_TYPE") {
 	case "github":
 		getOrSetGitHubToken()

--- a/configs/configs_token_test.go
+++ b/configs/configs_token_test.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -95,10 +96,113 @@ func TestGetTokenFromFile(t *testing.T) {
 	}
 }
 
+func TestRunTokenCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("runTokenCmd test relies on a unix shell")
+	}
+
+	// Env vars touched by runTokenCmd, cleared before each subtest.
+	tokenEnvs := []string{
+		"GHORG_TOKEN_CMD",
+		"GHORG_SCM_TYPE",
+		"GHORG_GITHUB_TOKEN",
+		"GHORG_GITLAB_TOKEN",
+		"GHORG_GITEA_TOKEN",
+		"GHORG_SOURCEHUT_TOKEN",
+		"GHORG_BITBUCKET_USERNAME",
+		"GHORG_BITBUCKET_API_EMAIL",
+		"GHORG_BITBUCKET_APP_PASSWORD",
+		"GHORG_BITBUCKET_API_TOKEN",
+		"GHORG_BITBUCKET_OAUTH_TOKEN",
+	}
+	clearEnvs := func() {
+		for _, e := range tokenEnvs {
+			os.Unsetenv(e)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		setup    map[string]string
+		checkEnv string
+		expected string
+	}{
+		{
+			name:     "github_sets_token",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "github", "GHORG_TOKEN_CMD": "echo gh-token"},
+			checkEnv: "GHORG_GITHUB_TOKEN",
+			expected: "gh-token",
+		},
+		{
+			name:     "gitlab_sets_token",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "gitlab", "GHORG_TOKEN_CMD": "echo gl-token"},
+			checkEnv: "GHORG_GITLAB_TOKEN",
+			expected: "gl-token",
+		},
+		{
+			name:     "output_is_trimmed",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "gitea", "GHORG_TOKEN_CMD": "printf '  gt-token \\n'"},
+			checkEnv: "GHORG_GITEA_TOKEN",
+			expected: "gt-token",
+		},
+		{
+			name:     "existing_token_takes_precedence",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "github", "GHORG_GITHUB_TOKEN": "already-set", "GHORG_TOKEN_CMD": "echo from-cmd"},
+			checkEnv: "GHORG_GITHUB_TOKEN",
+			expected: "already-set",
+		},
+		{
+			name:     "bitbucket_username_uses_app_password",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "bitbucket", "GHORG_BITBUCKET_USERNAME": "user", "GHORG_TOKEN_CMD": "echo bb-app"},
+			checkEnv: "GHORG_BITBUCKET_APP_PASSWORD",
+			expected: "bb-app",
+		},
+		{
+			name:     "bitbucket_api_email_uses_api_token",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "bitbucket", "GHORG_BITBUCKET_API_EMAIL": "user@example.com", "GHORG_TOKEN_CMD": "echo bb-api"},
+			checkEnv: "GHORG_BITBUCKET_API_TOKEN",
+			expected: "bb-api",
+		},
+		{
+			name:     "bitbucket_default_uses_oauth",
+			setup:    map[string]string{"GHORG_SCM_TYPE": "bitbucket", "GHORG_TOKEN_CMD": "echo bb-oauth"},
+			checkEnv: "GHORG_BITBUCKET_OAUTH_TOKEN",
+			expected: "bb-oauth",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnvs()
+			defer clearEnvs()
+			for k, v := range tt.setup {
+				os.Setenv(k, v)
+			}
+
+			runTokenCmd()
+
+			if got := os.Getenv(tt.checkEnv); got != tt.expected {
+				t.Errorf("%s = %q, expected %q", tt.checkEnv, got, tt.expected)
+			}
+		})
+	}
+
+	t.Run("noop_when_cmd_unset", func(t *testing.T) {
+		clearEnvs()
+		defer clearEnvs()
+		os.Setenv("GHORG_SCM_TYPE", "github")
+
+		runTokenCmd()
+
+		if got := os.Getenv("GHORG_GITHUB_TOKEN"); got != "" {
+			t.Errorf("GHORG_GITHUB_TOKEN = %q, expected empty", got)
+		}
+	})
+}
+
 func TestGetTokenFromFileNonExistent(t *testing.T) {
 	// This test verifies that the function handles non-existent files properly
 	// Note: The current implementation calls log.Fatal, so we can't easily test this
 	// without changing the implementation. This is a design consideration for future improvement.
 	t.Skip("Skipping test for non-existent file as current implementation calls log.Fatal")
 }
-

--- a/sample-conf.yaml
+++ b/sample-conf.yaml
@@ -243,6 +243,15 @@ GHORG_EXIT_CODE_ON_CLONE_ISSUES: 1
 # flag (--no-token)
 GHORG_NO_TOKEN: false
 
+# Source your token from a command instead of storing it in cleartext.
+# The command is run through your shell (sh -c on unix, cmd /C on windows) and its
+# stdout (trimmed of surrounding whitespace) is used as the token for the active
+# GHORG_SCM_TYPE. Useful with external secrets managers (e.g. mise, pass, a keyring CLI).
+# An explicitly set token (GHORG_<SCM>_TOKEN, --token, etc.) always takes precedence,
+# so the command only runs when no token is already set.
+# e.g. GHORG_TOKEN_CMD: mise get GITLAB_TOKEN
+GHORG_TOKEN_CMD:
+
 # Skips the calculation of the output directory size at the end of a clone operation.
 # This can save time, especially when cloning a large number of repositories.
 # This is enabled by default


### PR DESCRIPTION
Add support for sourcing tokens from external commands via the GHORG_TOKEN_CMD environment variable. This allows users to integrate with external secrets managers (e.g. mise, pass, keyring CLIs) instead of storing tokens in cleartext. The command runs through the system shell and its stdout is used as the token for the active SCM type. Explicit tokens always take precedence, so the command only runs when no token is already set. Includes comprehensive tests for all supported SCM types and edge cases.

Fixes https://github.com/gabrie30/ghorg/issues/652